### PR TITLE
feat: Add Subject Categories, Subjects, & Press Release feature

### DIFF
--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -29,7 +29,6 @@ jobs:
       - name: 📦 Install Dependencies
         run: |
           flutter pub global activate very_good_cli
-          very_good --analytics false
           very_good packages get --recursive
       - name: Run Tests
         run: |

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -25,4 +25,4 @@ jobs:
     with:
       flutter_channel: stable
       min_coverage: 80
-      coverage_excludes: "**/*.config.dart **/register_module.dart **/http_*.dart **/*_interceptor.dart **/*_http_module.dart **/*_log_*.dart **/*.g.dart **/*.freezed.dart **/*_serializer.dart **/service_locator.dart **/env.dart **/usecase.dart"
+      coverage_excludes: "**/*.config.dart **/register_module.dart **/http_*.dart **/*_http_module.dart **/*_log_*.dart **/*.g.dart **/*.freezed.dart **/*_serializer.dart **/service_locator.dart **/env.dart **/usecase.dart"

--- a/example/lib/app/modules/domain/views/domain_view.dart
+++ b/example/lib/app/modules/domain/views/domain_view.dart
@@ -175,7 +175,8 @@ class DomainView extends GetView<DomainController> {
               onLoading: Expanded(
                 child: Skeletonizer(
                   enabled: true,
-                  child: ListView.builder(
+                  child: ListView.separated(
+                    separatorBuilder: (_, __) => const Divider(),
                     itemBuilder: (_, __) => const DomainCard(
                       id: '0000',
                       title: 'Provinsi Dummy',

--- a/example/lib/app/modules/home/controllers/home_controller.dart
+++ b/example/lib/app/modules/home/controllers/home_controller.dart
@@ -1,7 +1,3 @@
 import 'package:get/get.dart';
 
-class HomeController extends GetxController {
-  final count = 0.obs;
-
-  void increment() => count.value++;
-}
+class HomeController extends GetxController {}

--- a/example/lib/app/modules/home/views/home_view.dart
+++ b/example/lib/app/modules/home/views/home_view.dart
@@ -27,8 +27,11 @@ class HomeView extends GetView<HomeController> {
           const _Button('Infographics', Routes.INFOGRAPHIC),
           const _Button('News', Routes.NEWS),
           const _Button('News Categories', Routes.NEWS_CATEGORY),
+          const _Button('Press Releases', Routes.PRESS_RELEASE),
           const _Button('Publications', Routes.PUBLICATION),
           const _Button('Static Tables', Routes.STATIC_TABLE),
+          const _Button('Subject Categories', Routes.SUBJECT_CATEGORY),
+          const _Button('Subjects', Routes.SUBJECT),
         ],
       ),
     );

--- a/example/lib/app/modules/infographic/controllers/infographic_controller.dart
+++ b/example/lib/app/modules/infographic/controllers/infographic_controller.dart
@@ -3,7 +3,7 @@ import 'package:stadata_flutter_sdk/stadata_flutter_sdk.dart';
 
 class InfographicController extends GetxController
     with StateMixin<ListResult<Infographic>> {
-  final domain = Rx('7200');
+  final domain = Rx('0000');
   final page = Rx('1');
   final keyword = Rxn<String>();
   final selectedLang = Rx(DataLanguage.id);

--- a/example/lib/app/modules/infographic/views/infographic_view.dart
+++ b/example/lib/app/modules/infographic/views/infographic_view.dart
@@ -197,7 +197,8 @@ class InfographicView extends GetView<InfographicController> {
               ),
               onLoading: Skeletonizer(
                 enabled: true,
-                child: ListView.builder(
+                child: ListView.separated(
+                  separatorBuilder: (_, __) => const Divider(),
                   physics: const NeverScrollableScrollPhysics(),
                   shrinkWrap: true,
                   itemBuilder: (_, __) => const InfographicCard(

--- a/example/lib/app/modules/news/controllers/news_controller.dart
+++ b/example/lib/app/modules/news/controllers/news_controller.dart
@@ -4,7 +4,7 @@ import 'package:stadata_flutter_sdk/stadata_flutter_sdk.dart';
 
 class NewsController extends GetxController with StateMixin<ListResult<News>> {
   final selectedLang = Rx(DataLanguage.id);
-  final domain = Rx<String>('7200');
+  final domain = Rx<String>('0000');
   final keyword = Rxn<String>();
   final page = Rx<String>('1');
   final date = Rxn<DateTime>();

--- a/example/lib/app/modules/news/views/news_view.dart
+++ b/example/lib/app/modules/news/views/news_view.dart
@@ -1,3 +1,4 @@
+import 'package:easy_debounce/easy_debounce.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
 
@@ -34,7 +35,17 @@ class NewsView extends GetView<NewsController> {
             8.verticalSpace,
             TextFormField(
               maxLength: 4,
-              onChanged: (value) => controller.domain.value = value,
+              onChanged: (value) {
+                controller.domain.value = value;
+                EasyDebounce.debounce(
+                  'reloadNewsCategories',
+                  const Duration(milliseconds: 500),
+                  () {
+                    controller.newsCategory.value = null;
+                    controller.loadNewsCategories();
+                  },
+                );
+              },
               keyboardType: TextInputType.number,
               initialValue: controller.domain.value,
               decoration: InputDecoration(
@@ -67,6 +78,8 @@ class NewsView extends GetView<NewsController> {
                   if (selectedType == null) return;
 
                   controller.selectedLang.value = selectedType;
+                  controller.newsCategory.value = null;
+                  controller.loadNewsCategories();
                 },
               ),
             ),
@@ -273,7 +286,8 @@ class NewsView extends GetView<NewsController> {
               ),
               onLoading: Skeletonizer(
                 enabled: true,
-                child: ListView.builder(
+                child: ListView.separated(
+                  separatorBuilder: (_, __) => const Divider(),
                   physics: const NeverScrollableScrollPhysics(),
                   shrinkWrap: true,
                   itemBuilder: (_, __) => NewsCard(

--- a/example/lib/app/modules/news_category/controllers/news_category_controller.dart
+++ b/example/lib/app/modules/news_category/controllers/news_category_controller.dart
@@ -3,7 +3,7 @@ import 'package:stadata_flutter_sdk/stadata_flutter_sdk.dart';
 
 class NewsCategoryController extends GetxController
     with StateMixin<ListResult<NewsCategory>> {
-  final domain = Rx('7200');
+  final domain = Rx('0000');
   final selectedLang = Rx<DataLanguage>(DataLanguage.id);
 
   @override

--- a/example/lib/app/modules/news_category/views/news_category_view.dart
+++ b/example/lib/app/modules/news_category/views/news_category_view.dart
@@ -171,7 +171,8 @@ class NewsCategoryView extends GetView<NewsCategoryController> {
               onLoading: Expanded(
                 child: Skeletonizer(
                   enabled: true,
-                  child: ListView.builder(
+                  child: ListView.separated(
+                    separatorBuilder: (_, __) => const Divider(),
                     itemBuilder: (_, __) => const ListTile(
                       title: Text('News Category ID'),
                       subtitle: Text('News Category Name'),

--- a/example/lib/app/modules/press_release/bindings/press_release_binding.dart
+++ b/example/lib/app/modules/press_release/bindings/press_release_binding.dart
@@ -1,0 +1,12 @@
+import 'package:get/get.dart';
+
+import '../controllers/press_release_controller.dart';
+
+class PressReleaseBinding extends Bindings {
+  @override
+  void dependencies() {
+    Get.lazyPut<PressReleaseController>(
+      () => PressReleaseController(),
+    );
+  }
+}

--- a/example/lib/app/modules/press_release/controllers/press_release_controller.dart
+++ b/example/lib/app/modules/press_release/controllers/press_release_controller.dart
@@ -1,0 +1,48 @@
+import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+import 'package:stadata_flutter_sdk/stadata_flutter_sdk.dart';
+
+class PressReleaseController extends GetxController
+    with StateMixin<ListResult<PressRelease>> {
+  final selectedLang = Rx(DataLanguage.id);
+  final domain = '0000'.obs;
+  final page = '1'.obs;
+  final keyword = Rxn<String>();
+  final date = Rxn<DateTime>();
+  late final TextEditingController dateCtl;
+
+  @override
+  void onInit() {
+    dateCtl = TextEditingController();
+    loadPressReleases();
+    super.onInit();
+  }
+
+  Future loadPressReleases() async {
+    try {
+      change(null, status: RxStatus.loading());
+      final result = await StadataFlutter.instance.list.pressReleases(
+        domain: domain.value,
+        lang: selectedLang.value,
+        keyword: keyword.value,
+        page: int.parse(page.value),
+        year: date.value != null ? date.value!.year : null,
+        month: date.value != null ? date.value!.month : null,
+      );
+
+      if (result.data.isEmpty) {
+        change(null, status: RxStatus.empty());
+      } else {
+        change(result, status: RxStatus.success());
+      }
+    } catch (e) {
+      change(null, status: RxStatus.error(e.toString()));
+    }
+  }
+
+  @override
+  void onClose() {
+    dateCtl.dispose();
+    super.onClose();
+  }
+}

--- a/example/lib/app/modules/press_release/views/press_release_view.dart
+++ b/example/lib/app/modules/press_release/views/press_release_view.dart
@@ -1,0 +1,268 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_screenutil/flutter_screenutil.dart';
+
+import 'package:get/get.dart';
+import 'package:month_year_picker/month_year_picker.dart';
+import 'package:skeletonizer/skeletonizer.dart';
+import 'package:stadata_example/app/routes/app_pages.dart';
+import 'package:stadata_example/app/shared/widgets/press_release_card.dart';
+import 'package:stadata_example/app/utils/date_formatter.dart';
+import 'package:stadata_flutter_sdk/stadata_flutter_sdk.dart';
+
+import '../controllers/press_release_controller.dart';
+
+class PressReleaseView extends GetView<PressReleaseController> {
+  const PressReleaseView({Key? key}) : super(key: key);
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Press Release Page'),
+        centerTitle: true,
+      ),
+      body: SingleChildScrollView(
+        padding: EdgeInsets.all(16.r),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              'Custom Param',
+              style: Theme.of(context).textTheme.titleLarge,
+            ),
+            8.verticalSpace,
+            TextFormField(
+              maxLength: 4,
+              onChanged: (value) => controller.domain.value = value,
+              keyboardType: TextInputType.number,
+              initialValue: controller.domain.value,
+              decoration: InputDecoration(
+                border: OutlineInputBorder(
+                  borderRadius: BorderRadius.circular(10),
+                ),
+                labelText: 'Domain (domain) - required',
+              ),
+            ),
+            8.verticalSpace,
+            Obx(
+              () => DropdownButtonFormField(
+                decoration: InputDecoration(
+                  border: OutlineInputBorder(
+                    borderRadius: BorderRadius.circular(8),
+                  ),
+                  isDense: true,
+                  labelText: 'Language (lang) - required',
+                ),
+                value: controller.selectedLang.value,
+                items: DataLanguage.values
+                    .map(
+                      (e) => DropdownMenuItem<DataLanguage>(
+                        value: e,
+                        child: Text('${e.name} - ${e.value}'),
+                      ),
+                    )
+                    .toList(),
+                onChanged: (selectedType) {
+                  if (selectedType == null) return;
+
+                  controller.selectedLang.value = selectedType;
+                },
+              ),
+            ),
+            8.verticalSpace,
+            TextFormField(
+              onChanged: (value) => controller.keyword.value = value,
+              keyboardType: TextInputType.text,
+              initialValue: controller.keyword.value,
+              decoration: InputDecoration(
+                border: OutlineInputBorder(
+                  borderRadius: BorderRadius.circular(10),
+                ),
+                labelText: 'Keyword (keyword) - optional',
+              ),
+            ),
+            16.verticalSpace,
+            TextFormField(
+              onChanged: (value) => controller.page.value = value,
+              keyboardType: TextInputType.number,
+              initialValue: controller.page.value,
+              decoration: InputDecoration(
+                border: OutlineInputBorder(
+                  borderRadius: BorderRadius.circular(10),
+                ),
+                labelText: 'Page (page) - optional',
+              ),
+            ),
+            16.verticalSpace,
+            TextFormField(
+              controller: controller.dateCtl,
+              onTap: () async {
+                final result = await showMonthYearPicker(
+                  context: context,
+                  initialDate: controller.date.value ?? DateTime.now(),
+                  firstDate: DateTime.now().subtract(
+                    const Duration(
+                      days: 365 * 5,
+                    ),
+                  ),
+                  lastDate: DateTime.now(),
+                );
+                controller.date.value = result;
+                controller.dateCtl.text = DateFormatter.formatDate(
+                  'MMMM y',
+                  result,
+                );
+              },
+              readOnly: true,
+              keyboardType: TextInputType.number,
+              decoration: InputDecoration(
+                border: OutlineInputBorder(
+                  borderRadius: BorderRadius.circular(10),
+                ),
+                labelText: 'Month & Year (month & year) - optional',
+              ),
+            ),
+            16.verticalSpace,
+            SizedBox(
+              width: double.infinity,
+              child: FilledButton(
+                onPressed: () {
+                  FocusScope.of(context).unfocus();
+                  controller.loadPressReleases();
+                },
+                child: const Text('Submit'),
+              ),
+            ),
+            16.verticalSpace,
+            Text(
+              'Pagination',
+              style: Theme.of(context).textTheme.titleLarge,
+            ),
+            8.verticalSpace,
+            controller.obx(
+              (state) => IntrinsicHeight(
+                child: SingleChildScrollView(
+                  scrollDirection: Axis.horizontal,
+                  child: Row(
+                    children: [
+                      Text(
+                        'Page : ${state?.pagination?.page ?? 0}',
+                      ),
+                      const VerticalDivider(
+                        color: Colors.blueGrey,
+                      ),
+                      Text(
+                        'Pages : ${state?.pagination?.pages ?? 0}',
+                      ),
+                      const VerticalDivider(
+                        color: Colors.blueGrey,
+                      ),
+                      Text(
+                        'Per Page : ${state?.pagination?.perPage ?? 0}',
+                      ),
+                      const VerticalDivider(
+                        color: Colors.blueGrey,
+                      ),
+                      Text(
+                        'Total : ${state?.pagination?.total ?? 0}',
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+              onLoading: const Skeletonizer(
+                enabled: true,
+                child: IntrinsicHeight(
+                  child: SingleChildScrollView(
+                    scrollDirection: Axis.horizontal,
+                    child: Row(
+                      children: [
+                        Text(
+                          'Page : ',
+                        ),
+                        VerticalDivider(
+                          color: Colors.blueGrey,
+                        ),
+                        Text(
+                          'Pages : ',
+                        ),
+                        VerticalDivider(
+                          color: Colors.blueGrey,
+                        ),
+                        Text(
+                          'Per Page : ',
+                        ),
+                        VerticalDivider(
+                          color: Colors.blueGrey,
+                        ),
+                        Text(
+                          'Total : ',
+                        ),
+                      ],
+                    ),
+                  ),
+                ),
+              ),
+            ),
+            16.verticalSpace,
+            Text(
+              'Result',
+              style: Theme.of(context).textTheme.titleLarge,
+            ),
+            controller.obx(
+              (state) => ListView.separated(
+                shrinkWrap: true,
+                padding: EdgeInsets.zero,
+                physics: const NeverScrollableScrollPhysics(),
+                itemBuilder: (context, index) {
+                  if (state == null) {
+                    return const SizedBox();
+                  }
+                  final pressRelease = state.data[index];
+                  return PressReleaseCard(
+                    cover: pressRelease.cover,
+                    title: pressRelease.title,
+                    onTap: () {
+                      Get.toNamed(
+                        Routes.PRESS_RELEASE_DETAIL,
+                        arguments: {
+                          'id': pressRelease.id.toString(),
+                          'lang': controller.selectedLang.value,
+                          'domain': controller.domain.value,
+                        },
+                      );
+                    },
+                  );
+                },
+                separatorBuilder: (_, __) => const Divider(),
+                itemCount: state?.data.length ?? 0,
+              ),
+              onLoading: Skeletonizer(
+                enabled: true,
+                child: ListView.separated(
+                  padding: EdgeInsets.zero,
+                  physics: const NeverScrollableScrollPhysics(),
+                  shrinkWrap: true,
+                  separatorBuilder: (_, __) => const Divider(),
+                  itemBuilder: (_, __) => const PressReleaseCard(
+                    cover:
+                        'https://fikrirasyid.com/wp-content/uploads/2016/10/placeholder-portrait-9-16.jpg',
+                    title: 'Press release Title Example',
+                  ),
+                  itemCount: 10,
+                ),
+              ),
+              onError: (error) => Center(
+                child: Text(
+                  error.toString(),
+                ),
+              ),
+              onEmpty: const Center(
+                child: Text('Empty'),
+              ),
+            )
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/example/lib/app/modules/press_release_detail/bindings/press_release_detail_binding.dart
+++ b/example/lib/app/modules/press_release_detail/bindings/press_release_detail_binding.dart
@@ -1,0 +1,12 @@
+import 'package:get/get.dart';
+
+import '../controllers/press_release_detail_controller.dart';
+
+class PressReleaseDetailBinding extends Bindings {
+  @override
+  void dependencies() {
+    Get.lazyPut<PressReleaseDetailController>(
+      () => PressReleaseDetailController(),
+    );
+  }
+}

--- a/example/lib/app/modules/press_release_detail/controllers/press_release_detail_controller.dart
+++ b/example/lib/app/modules/press_release_detail/controllers/press_release_detail_controller.dart
@@ -1,0 +1,37 @@
+import 'package:get/get.dart';
+import 'package:stadata_flutter_sdk/stadata_flutter_sdk.dart';
+
+class PressReleaseDetailController extends GetxController
+    with StateMixin<PressRelease> {
+  final id = '0'.obs;
+  final domain = '0000'.obs;
+  final lang = Rx(DataLanguage.id);
+
+  @override
+  void onInit() {
+    id.value = Get.arguments['id'];
+    domain.value = Get.arguments['domain'];
+    lang.value = Get.arguments['lang'];
+    loadPressReleaseDetail();
+    super.onInit();
+  }
+
+  Future loadPressReleaseDetail() async {
+    try {
+      change(null, status: RxStatus.loading());
+      final result = await StadataFlutter.instance.view.pressRelease(
+        lang: lang.value,
+        id: int.parse(id.value),
+        domain: domain.value,
+      );
+
+      if (result == null) {
+        change(null, status: RxStatus.empty());
+      } else {
+        change(result, status: RxStatus.success());
+      }
+    } catch (e) {
+      change(null, status: RxStatus.error(e.toString()));
+    }
+  }
+}

--- a/example/lib/app/modules/press_release_detail/views/press_release_detail_view.dart
+++ b/example/lib/app/modules/press_release_detail/views/press_release_detail_view.dart
@@ -1,0 +1,276 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_screenutil/flutter_screenutil.dart';
+import 'package:flutter_widget_from_html/flutter_widget_from_html.dart';
+
+import 'package:get/get.dart';
+import 'package:skeletonizer/skeletonizer.dart';
+import 'package:stadata_example/app/shared/widgets/network_image.dart';
+import 'package:stadata_example/app/utils/date_formatter.dart';
+
+import '../controllers/press_release_detail_controller.dart';
+
+class PressReleaseDetailView extends GetView<PressReleaseDetailController> {
+  const PressReleaseDetailView({Key? key}) : super(key: key);
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Press Release Detail'),
+        centerTitle: true,
+      ),
+      body: SingleChildScrollView(
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            controller.obx(
+              (state) => AppNetworkImage(
+                url: state!.cover,
+                width: 1.sw,
+                height: 0.25.sh,
+                borderRadius: BorderRadius.zero,
+              ),
+              onLoading: Skeletonizer(
+                enabled: true,
+                child: AppNetworkImage(
+                  url:
+                      'https://fikrirasyid.com/wp-content/uploads/2016/10/placeholder-portrait-9-16.jpg',
+                  width: 1.sw,
+                  height: 0.25.sh,
+                  borderRadius: BorderRadius.zero,
+                ),
+              ),
+            ),
+            16.verticalSpace,
+            controller.obx(
+                (state) => _PressReleaseDetailSection(
+                      title: state!.title,
+                      abstract: state.abstract,
+                      fileSize: state.size,
+                      updatedAt: state.updatedAt,
+                      releaseDate: state.releaseDate,
+                      pdfUrl: state.pdf,
+                      slideUrl: state.slide,
+                    ),
+                onLoading: Skeletonizer(
+                  enabled: true,
+                  child: _PressReleaseDetailSection(
+                    title:
+                        'Title of Press Release Title of Press Release Title of Press Release',
+                    abstract: 'Lorem ipsum dolor',
+                    fileSize: '18 MB',
+                    releaseDate: DateTime.now(),
+                    pdfUrl: 'urlurlurlurlurlurlurlurlurlurlurlurlurl',
+                    slideUrl: 'urlurlurlurlurlurlurlurlurlurlurlurlurl',
+                  ),
+                ))
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _PressReleaseDetailSection extends StatelessWidget {
+  const _PressReleaseDetailSection({
+    required this.title,
+    required this.abstract,
+    required this.fileSize,
+    required this.releaseDate,
+    required this.pdfUrl,
+    required this.slideUrl,
+    this.updatedAt,
+  });
+
+  final String title;
+  final String abstract;
+  final String fileSize;
+  final DateTime? updatedAt;
+  final DateTime releaseDate;
+  final String pdfUrl;
+  final String slideUrl;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final textTheme = theme.textTheme;
+    return Padding(
+      padding: EdgeInsets.all(16.r),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            title,
+            style: textTheme.titleLarge,
+          ),
+          16.verticalSpace,
+          Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              const Expanded(
+                child: Skeleton.keep(
+                  child: Text('Release Date :'),
+                ),
+              ),
+              Expanded(
+                child: Text(
+                  DateFormatter.formatDate('EEEE, dd MMMM y', releaseDate),
+                  maxLines: 1,
+                  style: textTheme.bodySmall,
+                  overflow: TextOverflow.ellipsis,
+                ),
+              ),
+            ],
+          ),
+          8.verticalSpace,
+          Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              const Expanded(
+                child: Skeleton.keep(
+                  child: Text('Updated Date :'),
+                ),
+              ),
+              Expanded(
+                child: Text(
+                  DateFormatter.formatDate(
+                    'EEEE, dd MMMM y',
+                    updatedAt,
+                    placeholder: 'No Changes Made',
+                  ),
+                  maxLines: 1,
+                  style: textTheme.bodySmall,
+                  overflow: TextOverflow.ellipsis,
+                ),
+              ),
+            ],
+          ),
+          const Divider(),
+          Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              const Expanded(
+                flex: 2,
+                child: Skeleton.keep(
+                  child: Text('PDF Url :'),
+                ),
+              ),
+              Expanded(
+                flex: 3,
+                child: Text(
+                  pdfUrl,
+                  maxLines: 1,
+                  style: textTheme.bodySmall,
+                  overflow: TextOverflow.ellipsis,
+                ),
+              ),
+              Expanded(
+                flex: 1,
+                child: Skeleton.keep(
+                  child: IconButton.filled(
+                    onPressed: () {
+                      Clipboard.setData(
+                        ClipboardData(text: pdfUrl),
+                      );
+                      ScaffoldMessenger.of(context).hideCurrentSnackBar();
+                      ScaffoldMessenger.of(context).showSnackBar(
+                        const SnackBar(
+                          content: Text('Link berhasil disalin!'),
+                          backgroundColor: Colors.green,
+                        ),
+                      );
+                    },
+                    icon: Icon(
+                      Icons.copy,
+                      size: 16.sp,
+                    ),
+                  ),
+                ),
+              )
+            ],
+          ),
+          Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              const Expanded(
+                flex: 2,
+                child: Skeleton.keep(
+                  child: Text('Slide Url :'),
+                ),
+              ),
+              Expanded(
+                flex: 3,
+                child: Text(
+                  slideUrl,
+                  maxLines: 1,
+                  style: textTheme.bodySmall,
+                  overflow: TextOverflow.ellipsis,
+                ),
+              ),
+              Expanded(
+                flex: 1,
+                child: Skeleton.keep(
+                  child: IconButton.filled(
+                    onPressed: () {
+                      Clipboard.setData(
+                        ClipboardData(text: slideUrl),
+                      );
+                      ScaffoldMessenger.of(context).hideCurrentSnackBar();
+                      ScaffoldMessenger.of(context).showSnackBar(
+                        const SnackBar(
+                          content: Text('Link berhasil disalin!'),
+                          backgroundColor: Colors.green,
+                        ),
+                      );
+                    },
+                    icon: Icon(
+                      Icons.copy,
+                      size: 16.sp,
+                    ),
+                  ),
+                ),
+              )
+            ],
+          ),
+          Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              const Expanded(
+                flex: 2,
+                child: Skeleton.keep(
+                  child: Text('File Size : '),
+                ),
+              ),
+              Expanded(
+                flex: 3,
+                child: Text(
+                  fileSize,
+                  maxLines: 1,
+                  style: textTheme.bodySmall,
+                  overflow: TextOverflow.ellipsis,
+                ),
+              ),
+              Expanded(
+                flex: 1,
+                child: Skeleton.keep(
+                  child: IconButton.filled(
+                    onPressed: () {},
+                    icon: Icon(
+                      Icons.file_download,
+                      size: 18.sp,
+                    ),
+                  ),
+                ),
+              )
+            ],
+          ),
+          const Divider(),
+          HtmlWidget(
+            abstract,
+            textStyle: textTheme.bodySmall,
+          )
+        ],
+      ),
+    );
+  }
+}

--- a/example/lib/app/modules/publication/controllers/publication_controller.dart
+++ b/example/lib/app/modules/publication/controllers/publication_controller.dart
@@ -5,7 +5,7 @@ import 'package:stadata_flutter_sdk/stadata_flutter_sdk.dart';
 class PublicationController extends GetxController
     with StateMixin<ListResult<Publication>> {
   final selectedLang = Rx(DataLanguage.id);
-  final domain = Rx<String>('7200');
+  final domain = Rx<String>('0000');
   final keyword = Rxn<String>();
   final page = Rx<String>('1');
   final date = Rxn<DateTime>();

--- a/example/lib/app/modules/publication/views/publication_view.dart
+++ b/example/lib/app/modules/publication/views/publication_view.dart
@@ -240,7 +240,8 @@ class PublicationView extends GetView<PublicationController> {
               ),
               onLoading: Skeletonizer(
                 enabled: true,
-                child: ListView.builder(
+                child: ListView.separated(
+                  separatorBuilder: (_, __) => const Divider(),
                   physics: const NeverScrollableScrollPhysics(),
                   shrinkWrap: true,
                   itemBuilder: (_, __) => const PublicationCard(

--- a/example/lib/app/modules/publication_detail/views/publication_detail_view.dart
+++ b/example/lib/app/modules/publication_detail/views/publication_detail_view.dart
@@ -1,5 +1,6 @@
 // ignore_for_file: unused_element
 
+import 'package:animate_do/animate_do.dart';
 import 'package:drop_shadow/drop_shadow.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
@@ -63,12 +64,18 @@ class PublicationDetailView extends GetView<PublicationDetailController> {
                             ),
                           ),
                           16.verticalSpace,
-                          _PublicationTitleWidget(
-                            title: state?.title,
+                          FadeInDown(
+                            from: 10,
+                            child: _PublicationTitleWidget(
+                              title: state?.title,
+                            ),
                           ),
                           8.verticalSpace,
-                          _PublicationReleaseDateWidget(
-                            releaseDate: state?.releaseDate,
+                          FadeInDown(
+                            from: 10,
+                            child: _PublicationReleaseDateWidget(
+                              releaseDate: state?.releaseDate,
+                            ),
                           )
                         ],
                       ),
@@ -111,9 +118,15 @@ class PublicationDetailView extends GetView<PublicationDetailController> {
                               ),
                             ),
                             16.verticalSpace,
-                            const _PublicationTitleWidget(),
+                            SizedBox(
+                              width: 0.9.sw,
+                              child: const _PublicationTitleWidget(),
+                            ),
                             8.verticalSpace,
-                            const _PublicationReleaseDateWidget()
+                            SizedBox(
+                              width: 0.25.sw,
+                              child: const _PublicationReleaseDateWidget(),
+                            )
                           ],
                         ),
                       ),
@@ -195,8 +208,11 @@ class _PublicationDetailSection extends StatelessWidget {
                               child: Icon(Icons.edit_calendar_rounded)),
                           8.horizontalSpace,
                           Expanded(
-                            child: _LastUpdateWidget(
-                              publication: publication,
+                            child: FadeInUp(
+                              from: 10,
+                              child: _LastUpdateWidget(
+                                publication: publication,
+                              ),
                             ),
                           )
                         ],
@@ -236,8 +252,11 @@ class _PublicationDetailSection extends StatelessWidget {
                               child: Icon(Icons.book_outlined)),
                           8.horizontalSpace,
                           Expanded(
-                            child: _PublicationNumberWidget(
-                              publication: publication,
+                            child: FadeInUp(
+                              from: 10,
+                              child: _PublicationNumberWidget(
+                                publication: publication,
+                              ),
                             ),
                           ),
                         ],
@@ -277,8 +296,11 @@ class _PublicationDetailSection extends StatelessWidget {
                               child: Icon(Icons.file_present_outlined)),
                           8.horizontalSpace,
                           Expanded(
-                            child: _CatalogueNumberWidget(
-                              publication: publication,
+                            child: FadeInUp(
+                              from: 10,
+                              child: _CatalogueNumberWidget(
+                                publication: publication,
+                              ),
                             ),
                           ),
                         ],
@@ -315,8 +337,11 @@ class _PublicationDetailSection extends StatelessWidget {
                           const Skeleton.shade(
                               child: Icon(Icons.confirmation_number_outlined)),
                           8.horizontalSpace,
-                          _ISSNWidget(
-                            publication: publication,
+                          FadeInUp(
+                            from: 10,
+                            child: _ISSNWidget(
+                              publication: publication,
+                            ),
                           ),
                         ],
                       )
@@ -354,8 +379,11 @@ class _PublicationDetailSection extends StatelessWidget {
                           const Skeleton.shade(
                               child: Icon(Icons.attach_file_sharp)),
                           8.horizontalSpace,
-                          _FileSizeWidget(
-                            publication: publication,
+                          FadeInUp(
+                            from: 10,
+                            child: _FileSizeWidget(
+                              publication: publication,
+                            ),
                           ),
                         ],
                       )
@@ -377,9 +405,12 @@ class _PublicationDetailSection extends StatelessWidget {
             ),
           ),
           16.verticalSpace,
-          HtmlWidget(
-            publication?.abstract ?? '',
-            textStyle: textTheme.bodySmall,
+          FadeInUp(
+            from: 5,
+            child: HtmlWidget(
+              publication?.abstract ?? '',
+              textStyle: textTheme.bodySmall,
+            ),
           )
         ],
       );

--- a/example/lib/app/modules/static_table/controllers/static_table_controller.dart
+++ b/example/lib/app/modules/static_table/controllers/static_table_controller.dart
@@ -5,7 +5,7 @@ import 'package:stadata_flutter_sdk/stadata_flutter_sdk.dart';
 class StaticTableController extends GetxController
     with StateMixin<ListResult<StaticTable>> {
   final selectedLang = Rx(DataLanguage.id);
-  final domain = Rx<String>('7200');
+  final domain = Rx<String>('0000');
   final keyword = Rxn<String>();
   final page = Rx<String>('1');
   final date = Rxn<DateTime>();

--- a/example/lib/app/modules/static_table/views/static_table_view.dart
+++ b/example/lib/app/modules/static_table/views/static_table_view.dart
@@ -237,7 +237,8 @@ class StaticTableView extends GetView<StaticTableController> {
               ),
               onLoading: Skeletonizer(
                 enabled: true,
-                child: ListView.builder(
+                child: ListView.separated(
+                  separatorBuilder: (_, __) => const Divider(),
                   padding: EdgeInsets.zero,
                   physics: const NeverScrollableScrollPhysics(),
                   shrinkWrap: true,

--- a/example/lib/app/modules/subject/bindings/subject_binding.dart
+++ b/example/lib/app/modules/subject/bindings/subject_binding.dart
@@ -1,0 +1,12 @@
+import 'package:get/get.dart';
+
+import '../controllers/subject_controller.dart';
+
+class SubjectBinding extends Bindings {
+  @override
+  void dependencies() {
+    Get.lazyPut<SubjectController>(
+      () => SubjectController(),
+    );
+  }
+}

--- a/example/lib/app/modules/subject/controllers/subject_controller.dart
+++ b/example/lib/app/modules/subject/controllers/subject_controller.dart
@@ -1,0 +1,62 @@
+import 'package:get/get.dart';
+import 'package:stadata_flutter_sdk/stadata_flutter_sdk.dart';
+
+class SubjectController extends GetxController
+    with StateMixin<ListResult<Subject>> {
+  final domain = '0000'.obs;
+  final page = '1'.obs;
+  final selectedLang = Rx(DataLanguage.id);
+  final selectedSubjectCategory = Rxn<SubjectCategory>();
+
+  final isCategoryLoading = false.obs;
+  final isCategoryError = false.obs;
+  final categories = List<SubjectCategory>.empty(growable: true).obs;
+
+  @override
+  void onInit() {
+    loadSubjectCategories();
+    loadSubjects();
+    super.onInit();
+  }
+
+  Future loadSubjects() async {
+    try {
+      change(null, status: RxStatus.loading());
+      final result = await StadataFlutter.instance.list.subjects(
+        domain: domain.value,
+        lang: selectedLang.value,
+        page: int.parse(page.value),
+        subjectCategoryId: int.parse(
+          selectedSubjectCategory.value?.id.toString() ?? '0',
+        ),
+      );
+
+      if (result.data.isEmpty) {
+        change(null, status: RxStatus.empty());
+      } else {
+        change(result, status: RxStatus.success());
+      }
+    } catch (e) {
+      change(null, status: RxStatus.error(e.toString()));
+    }
+  }
+
+  Future loadSubjectCategories() async {
+    try {
+      isCategoryError.value = false;
+      isCategoryLoading.value = true;
+      final result = await StadataFlutter.instance.list.subjectCategories(
+        domain: domain.value,
+        lang: selectedLang.value,
+      );
+
+      if (result.data.isNotEmpty) {
+        categories.value = result.data;
+      }
+    } catch (e) {
+      isCategoryError.value = true;
+    } finally {
+      isCategoryLoading.value = false;
+    }
+  }
+}

--- a/example/lib/app/modules/subject/views/subject_view.dart
+++ b/example/lib/app/modules/subject/views/subject_view.dart
@@ -1,0 +1,257 @@
+import 'dart:developer';
+
+import 'package:easy_debounce/easy_debounce.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_screenutil/flutter_screenutil.dart';
+
+import 'package:get/get.dart';
+import 'package:skeletonizer/skeletonizer.dart';
+import 'package:stadata_flutter_sdk/stadata_flutter_sdk.dart';
+
+import '../controllers/subject_controller.dart';
+
+class SubjectView extends GetView<SubjectController> {
+  const SubjectView({Key? key}) : super(key: key);
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Subject Page'),
+        centerTitle: true,
+      ),
+      body: SingleChildScrollView(
+        padding: EdgeInsets.all(16.r),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              'Custom Param',
+              style: Theme.of(context).textTheme.titleLarge,
+            ),
+            8.verticalSpace,
+            TextFormField(
+              maxLength: 4,
+              onChanged: (value) {
+                controller.domain.value = value;
+                EasyDebounce.debounce(
+                  'reloadCategory',
+                  const Duration(milliseconds: 500),
+                  () {
+                    log('Called bang');
+                    controller.selectedSubjectCategory.value = null;
+                    controller.loadSubjectCategories();
+                  },
+                );
+              },
+              keyboardType: TextInputType.number,
+              initialValue: controller.domain.value,
+              decoration: InputDecoration(
+                border: OutlineInputBorder(
+                  borderRadius: BorderRadius.circular(10),
+                ),
+                labelText: 'Domain (domain) - required',
+              ),
+            ),
+            8.verticalSpace,
+            Obx(
+              () => DropdownButtonFormField(
+                decoration: InputDecoration(
+                  border: OutlineInputBorder(
+                    borderRadius: BorderRadius.circular(8),
+                  ),
+                  isDense: true,
+                  labelText: 'Language (lang) - required',
+                ),
+                value: controller.selectedLang.value,
+                items: DataLanguage.values
+                    .map(
+                      (e) => DropdownMenuItem<DataLanguage>(
+                        value: e,
+                        child: Text('${e.name} - ${e.value}'),
+                      ),
+                    )
+                    .toList(),
+                onChanged: (selectedType) {
+                  if (selectedType == null) return;
+
+                  controller.selectedLang.value = selectedType;
+                  controller.selectedSubjectCategory.value = null;
+                  controller.loadSubjectCategories();
+                },
+              ),
+            ),
+            8.verticalSpace,
+            Obx(
+              () => DropdownButtonFormField<SubjectCategory?>(
+                decoration: InputDecoration(
+                  border: OutlineInputBorder(
+                    borderRadius: BorderRadius.circular(8),
+                  ),
+                  isDense: true,
+                  labelText: 'Category - optional',
+                ),
+                value: controller.selectedSubjectCategory.value,
+                items: controller.categories
+                    .map(
+                      (e) => DropdownMenuItem<SubjectCategory>(
+                        value: e,
+                        child: Text(
+                          '${e.id} - ${e.name}',
+                          style: Theme.of(context).textTheme.bodySmall,
+                          maxLines: 1,
+                          overflow: TextOverflow.ellipsis,
+                        ),
+                      ),
+                    )
+                    .toList(),
+                onChanged: (category) {
+                  controller.selectedSubjectCategory.value = category;
+                },
+              ),
+            ),
+            16.verticalSpace,
+            TextFormField(
+              onChanged: (value) => controller.page.value = value,
+              keyboardType: TextInputType.number,
+              initialValue: controller.page.value,
+              decoration: InputDecoration(
+                border: OutlineInputBorder(
+                  borderRadius: BorderRadius.circular(10),
+                ),
+                labelText: 'Page (page) - optional',
+              ),
+            ),
+            16.verticalSpace,
+            SizedBox(
+              width: double.infinity,
+              child: FilledButton(
+                onPressed: () {
+                  FocusScope.of(context).unfocus();
+                  controller.loadSubjects();
+                },
+                child: const Text('Submit'),
+              ),
+            ),
+            16.verticalSpace,
+            Text(
+              'Pagination',
+              style: Theme.of(context).textTheme.titleLarge,
+            ),
+            8.verticalSpace,
+            controller.obx(
+              (state) => IntrinsicHeight(
+                child: SingleChildScrollView(
+                  scrollDirection: Axis.horizontal,
+                  child: Row(
+                    children: [
+                      Text(
+                        'Page : ${state?.pagination?.page ?? 0}',
+                      ),
+                      const VerticalDivider(
+                        color: Colors.blueGrey,
+                      ),
+                      Text(
+                        'Pages : ${state?.pagination?.pages ?? 0}',
+                      ),
+                      const VerticalDivider(
+                        color: Colors.blueGrey,
+                      ),
+                      Text(
+                        'Per Page : ${state?.pagination?.perPage ?? 0}',
+                      ),
+                      const VerticalDivider(
+                        color: Colors.blueGrey,
+                      ),
+                      Text(
+                        'Total : ${state?.pagination?.total ?? 0}',
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+              onLoading: const Skeletonizer(
+                enabled: true,
+                child: IntrinsicHeight(
+                  child: SingleChildScrollView(
+                    scrollDirection: Axis.horizontal,
+                    child: Row(
+                      children: [
+                        Text(
+                          'Page : ',
+                        ),
+                        VerticalDivider(
+                          color: Colors.blueGrey,
+                        ),
+                        Text(
+                          'Pages : ',
+                        ),
+                        VerticalDivider(
+                          color: Colors.blueGrey,
+                        ),
+                        Text(
+                          'Per Page : ',
+                        ),
+                        VerticalDivider(
+                          color: Colors.blueGrey,
+                        ),
+                        Text(
+                          'Total : ',
+                        ),
+                      ],
+                    ),
+                  ),
+                ),
+              ),
+            ),
+            16.verticalSpace,
+            Text(
+              'Result',
+              style: Theme.of(context).textTheme.titleLarge,
+            ),
+            16.verticalSpace,
+            controller.obx(
+              (state) => ListView.separated(
+                shrinkWrap: true,
+                physics: const NeverScrollableScrollPhysics(),
+                itemBuilder: (context, index) {
+                  if (state == null) {
+                    return const SizedBox();
+                  }
+                  final subject = state.data[index];
+
+                  return ListTile(
+                    title: Text(
+                      subject.name,
+                    ),
+                  );
+                },
+                separatorBuilder: (_, __) => const Divider(),
+                itemCount: state?.data.length ?? 0,
+              ),
+              onLoading: Skeletonizer(
+                enabled: true,
+                child: ListView.separated(
+                  separatorBuilder: (_, __) => const Divider(),
+                  physics: const NeverScrollableScrollPhysics(),
+                  shrinkWrap: true,
+                  itemBuilder: (_, __) => const ListTile(
+                    title: Text('Title example'),
+                  ),
+                  itemCount: 10,
+                ),
+              ),
+              onError: (error) => Center(
+                child: Text(
+                  error.toString(),
+                ),
+              ),
+              onEmpty: const Center(
+                child: Text('Empty'),
+              ),
+            )
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/example/lib/app/modules/subject_category/bindings/subject_category_binding.dart
+++ b/example/lib/app/modules/subject_category/bindings/subject_category_binding.dart
@@ -1,0 +1,12 @@
+import 'package:get/get.dart';
+
+import '../controllers/subject_category_controller.dart';
+
+class SubjectCategoryBinding extends Bindings {
+  @override
+  void dependencies() {
+    Get.lazyPut<SubjectCategoryController>(
+      () => SubjectCategoryController(),
+    );
+  }
+}

--- a/example/lib/app/modules/subject_category/controllers/subject_category_controller.dart
+++ b/example/lib/app/modules/subject_category/controllers/subject_category_controller.dart
@@ -1,0 +1,38 @@
+import 'package:get/get.dart';
+import 'package:stadata_flutter_sdk/stadata_flutter_sdk.dart';
+
+class SubjectCategoryController extends GetxController
+    with StateMixin<ListResult<SubjectCategory>> {
+  final domain = '0000'.obs;
+  final page = '1'.obs;
+  final selectedLang = Rx(DataLanguage.id);
+
+  @override
+  void onInit() {
+    loadSubjectCategories();
+    super.onInit();
+  }
+
+  Future loadSubjectCategories() async {
+    try {
+      change(null, status: RxStatus.loading());
+      final result = await StadataFlutter.instance.list.subjectCategories(
+        domain: domain.value,
+        lang: selectedLang.value,
+        page: int.parse(page.value),
+      );
+      if (result.data.isEmpty) {
+        change(null, status: RxStatus.empty());
+      } else {
+        change(result, status: RxStatus.success());
+      }
+    } catch (e) {
+      change(
+        null,
+        status: RxStatus.error(
+          e.toString(),
+        ),
+      );
+    }
+  }
+}

--- a/example/lib/app/modules/subject_category/views/subject_category_view.dart
+++ b/example/lib/app/modules/subject_category/views/subject_category_view.dart
@@ -1,0 +1,210 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_screenutil/flutter_screenutil.dart';
+
+import 'package:get/get.dart';
+import 'package:skeletonizer/skeletonizer.dart';
+import 'package:stadata_flutter_sdk/stadata_flutter_sdk.dart';
+
+import '../controllers/subject_category_controller.dart';
+
+class SubjectCategoryView extends GetView<SubjectCategoryController> {
+  const SubjectCategoryView({Key? key}) : super(key: key);
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Subject Category Page'),
+        centerTitle: true,
+      ),
+      body: SingleChildScrollView(
+        padding: EdgeInsets.all(16.r),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              'Custom Param',
+              style: Theme.of(context).textTheme.titleLarge,
+            ),
+            8.verticalSpace,
+            TextFormField(
+              maxLength: 4,
+              onChanged: (value) => controller.domain.value = value,
+              keyboardType: TextInputType.number,
+              initialValue: controller.domain.value,
+              decoration: InputDecoration(
+                border: OutlineInputBorder(
+                  borderRadius: BorderRadius.circular(10),
+                ),
+                labelText: 'Domain (domain) - required',
+              ),
+            ),
+            8.verticalSpace,
+            Obx(
+              () => DropdownButtonFormField(
+                decoration: InputDecoration(
+                  border: OutlineInputBorder(
+                    borderRadius: BorderRadius.circular(8),
+                  ),
+                  isDense: true,
+                  labelText: 'Language (lang) - required',
+                ),
+                value: controller.selectedLang.value,
+                items: DataLanguage.values
+                    .map(
+                      (e) => DropdownMenuItem<DataLanguage>(
+                        value: e,
+                        child: Text('${e.name} - ${e.value}'),
+                      ),
+                    )
+                    .toList(),
+                onChanged: (selectedType) {
+                  if (selectedType == null) return;
+
+                  controller.selectedLang.value = selectedType;
+                },
+              ),
+            ),
+            16.verticalSpace,
+            TextFormField(
+              onChanged: (value) => controller.page.value = value,
+              keyboardType: TextInputType.number,
+              initialValue: controller.page.value,
+              decoration: InputDecoration(
+                border: OutlineInputBorder(
+                  borderRadius: BorderRadius.circular(10),
+                ),
+                labelText: 'Page (page) - optional',
+              ),
+            ),
+            16.verticalSpace,
+            SizedBox(
+              width: double.infinity,
+              child: FilledButton(
+                onPressed: () {
+                  FocusScope.of(context).unfocus();
+                  controller.loadSubjectCategories();
+                },
+                child: const Text('Submit'),
+              ),
+            ),
+            16.verticalSpace,
+            Text(
+              'Pagination',
+              style: Theme.of(context).textTheme.titleLarge,
+            ),
+            8.verticalSpace,
+            controller.obx(
+              (state) => IntrinsicHeight(
+                child: SingleChildScrollView(
+                  scrollDirection: Axis.horizontal,
+                  child: Row(
+                    children: [
+                      Text(
+                        'Page : ${state?.pagination?.page ?? 0}',
+                      ),
+                      const VerticalDivider(
+                        color: Colors.blueGrey,
+                      ),
+                      Text(
+                        'Pages : ${state?.pagination?.pages ?? 0}',
+                      ),
+                      const VerticalDivider(
+                        color: Colors.blueGrey,
+                      ),
+                      Text(
+                        'Per Page : ${state?.pagination?.perPage ?? 0}',
+                      ),
+                      const VerticalDivider(
+                        color: Colors.blueGrey,
+                      ),
+                      Text(
+                        'Total : ${state?.pagination?.total ?? 0}',
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+              onLoading: const Skeletonizer(
+                enabled: true,
+                child: IntrinsicHeight(
+                  child: SingleChildScrollView(
+                    scrollDirection: Axis.horizontal,
+                    child: Row(
+                      children: [
+                        Text(
+                          'Page : ',
+                        ),
+                        VerticalDivider(
+                          color: Colors.blueGrey,
+                        ),
+                        Text(
+                          'Pages : ',
+                        ),
+                        VerticalDivider(
+                          color: Colors.blueGrey,
+                        ),
+                        Text(
+                          'Per Page : ',
+                        ),
+                        VerticalDivider(
+                          color: Colors.blueGrey,
+                        ),
+                        Text(
+                          'Total : ',
+                        ),
+                      ],
+                    ),
+                  ),
+                ),
+              ),
+            ),
+            16.verticalSpace,
+            Text(
+              'Result',
+              style: Theme.of(context).textTheme.titleLarge,
+            ),
+            16.verticalSpace,
+            controller.obx(
+              (state) => ListView.separated(
+                shrinkWrap: true,
+                physics: const NeverScrollableScrollPhysics(),
+                itemBuilder: (context, index) {
+                  if (state == null) {
+                    return const SizedBox();
+                  }
+                  final subjectCategory = state.data[index];
+                  return ListTile(
+                    title:
+                        Text('${subjectCategory.id} - ${subjectCategory.name}'),
+                  );
+                },
+                separatorBuilder: (_, __) => const Divider(),
+                itemCount: state?.data.length ?? 0,
+              ),
+              onLoading: Skeletonizer(
+                enabled: true,
+                child: ListView.separated(
+                  separatorBuilder: (_, __) => const Divider(),
+                  physics: const NeverScrollableScrollPhysics(),
+                  shrinkWrap: true,
+                  itemBuilder: (_, __) => const ListTile(
+                    title: Text('Title of Subject Category'),
+                  ),
+                  itemCount: 10,
+                ),
+              ),
+              onError: (error) => Center(
+                child: Text(
+                  error.toString(),
+                ),
+              ),
+              onEmpty: const Center(
+                child: Text('Empty'),
+              ),
+            )
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/example/lib/app/routes/app_pages.dart
+++ b/example/lib/app/routes/app_pages.dart
@@ -12,6 +12,10 @@ import '../modules/news_category/bindings/news_category_binding.dart';
 import '../modules/news_category/views/news_category_view.dart';
 import '../modules/news_detail/bindings/news_detail_binding.dart';
 import '../modules/news_detail/views/news_detail_view.dart';
+import '../modules/press_release/bindings/press_release_binding.dart';
+import '../modules/press_release/views/press_release_view.dart';
+import '../modules/press_release_detail/bindings/press_release_detail_binding.dart';
+import '../modules/press_release_detail/views/press_release_detail_view.dart';
 import '../modules/publication/bindings/publication_binding.dart';
 import '../modules/publication/views/publication_view.dart';
 import '../modules/publication_detail/bindings/publication_detail_binding.dart';
@@ -20,6 +24,10 @@ import '../modules/static_table/bindings/static_table_binding.dart';
 import '../modules/static_table/views/static_table_view.dart';
 import '../modules/static_table_detail/bindings/static_table_detail_binding.dart';
 import '../modules/static_table_detail/views/static_table_detail_view.dart';
+import '../modules/subject/bindings/subject_binding.dart';
+import '../modules/subject/views/subject_view.dart';
+import '../modules/subject_category/bindings/subject_category_binding.dart';
+import '../modules/subject_category/views/subject_category_view.dart';
 
 part 'app_routes.dart';
 
@@ -78,6 +86,26 @@ class AppPages {
       name: _Paths.NEWS_CATEGORY,
       page: () => const NewsCategoryView(),
       binding: NewsCategoryBinding(),
+    ),
+    GetPage(
+      name: _Paths.SUBJECT_CATEGORY,
+      page: () => const SubjectCategoryView(),
+      binding: SubjectCategoryBinding(),
+    ),
+    GetPage(
+      name: _Paths.SUBJECT,
+      page: () => const SubjectView(),
+      binding: SubjectBinding(),
+    ),
+    GetPage(
+      name: _Paths.PRESS_RELEASE,
+      page: () => const PressReleaseView(),
+      binding: PressReleaseBinding(),
+    ),
+    GetPage(
+      name: _Paths.PRESS_RELEASE_DETAIL,
+      page: () => const PressReleaseDetailView(),
+      binding: PressReleaseDetailBinding(),
     ),
   ];
 }

--- a/example/lib/app/routes/app_routes.dart
+++ b/example/lib/app/routes/app_routes.dart
@@ -13,6 +13,10 @@ abstract class Routes {
   static const NEWS = _Paths.NEWS;
   static const NEWS_DETAIL = _Paths.NEWS_DETAIL;
   static const NEWS_CATEGORY = _Paths.NEWS_CATEGORY;
+  static const SUBJECT_CATEGORY = _Paths.SUBJECT_CATEGORY;
+  static const SUBJECT = _Paths.SUBJECT;
+  static const PRESS_RELEASE = _Paths.PRESS_RELEASE;
+  static const PRESS_RELEASE_DETAIL = _Paths.PRESS_RELEASE_DETAIL;
 }
 
 abstract class _Paths {
@@ -27,4 +31,8 @@ abstract class _Paths {
   static const NEWS = '/news';
   static const NEWS_DETAIL = '/news-detail';
   static const NEWS_CATEGORY = '/news-category';
+  static const SUBJECT_CATEGORY = '/subject-category';
+  static const SUBJECT = '/subject';
+  static const PRESS_RELEASE = '/press-release';
+  static const PRESS_RELEASE_DETAIL = '/press-release-detail';
 }

--- a/example/lib/app/shared/widgets/press_release_card.dart
+++ b/example/lib/app/shared/widgets/press_release_card.dart
@@ -1,0 +1,65 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_screenutil/flutter_screenutil.dart';
+import 'package:stadata_example/app/shared/widgets/network_image.dart';
+
+class PressReleaseCard extends StatelessWidget {
+  const PressReleaseCard({
+    super.key,
+    required this.cover,
+    required this.title,
+    this.onTap,
+  });
+
+  final String cover;
+  final String title;
+  final GestureTapCallback? onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final textTheme = theme.textTheme;
+    return Material(
+      child: InkWell(
+        onTap: onTap,
+        borderRadius: BorderRadius.circular(10.r),
+        child: Stack(
+          children: [
+            AppNetworkImage(
+              url: cover,
+              width: 1.sw,
+              height: 0.25.sh,
+              fit: BoxFit.cover,
+            ),
+            Positioned(
+              left: 0,
+              bottom: 0,
+              right: 0,
+              child: Container(
+                padding: EdgeInsets.all(16.r),
+                decoration: BoxDecoration(
+                  color: Colors.blueGrey.withOpacity(0.8),
+                  borderRadius: BorderRadius.vertical(
+                    bottom: Radius.circular(10.r),
+                  ),
+                ),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      title,
+                      style: textTheme.titleLarge?.copyWith(
+                        color: Colors.white,
+                      ),
+                      maxLines: 2,
+                      overflow: TextOverflow.ellipsis,
+                    ),
+                  ],
+                ),
+              ),
+            )
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -22,6 +22,7 @@ dependencies:
   flutter_widget_from_html: ^0.10.5+3
   reading_time: ^2.0.0
   animate_do: ^3.1.2
+  easy_debounce: ^2.0.3
 
 dev_dependencies: 
   flutter_lints: ^2.0.0

--- a/lib/src/core/di/service_locator.config.dart
+++ b/lib/src/core/di/service_locator.config.dart
@@ -12,21 +12,21 @@
 import 'package:flutter_secure_storage/flutter_secure_storage.dart' as _i6;
 import 'package:get_it/get_it.dart' as _i1;
 import 'package:injectable/injectable.dart' as _i2;
-import 'package:logger/logger.dart' as _i23;
-import 'package:stadata_flutter_sdk/src/core/di/register_module.dart' as _i41;
-import 'package:stadata_flutter_sdk/src/core/log/log.dart' as _i22;
+import 'package:logger/logger.dart' as _i27;
+import 'package:stadata_flutter_sdk/src/core/di/register_module.dart' as _i54;
+import 'package:stadata_flutter_sdk/src/core/log/log.dart' as _i26;
 import 'package:stadata_flutter_sdk/src/core/network/http/http_client.dart'
-    as _i16;
-import 'package:stadata_flutter_sdk/src/core/network/http/modules/stadata_http_module.dart'
-    as _i33;
-import 'package:stadata_flutter_sdk/src/core/network/http/modules/stadata_list_http_module.dart'
-    as _i35;
-import 'package:stadata_flutter_sdk/src/core/network/http/modules/stadata_view_http_module.dart'
-    as _i37;
-import 'package:stadata_flutter_sdk/src/core/storage/local_storage.dart'
     as _i20;
+import 'package:stadata_flutter_sdk/src/core/network/http/modules/stadata_http_module.dart'
+    as _i40;
+import 'package:stadata_flutter_sdk/src/core/network/http/modules/stadata_list_http_module.dart'
+    as _i42;
+import 'package:stadata_flutter_sdk/src/core/network/http/modules/stadata_view_http_module.dart'
+    as _i44;
+import 'package:stadata_flutter_sdk/src/core/storage/local_storage.dart'
+    as _i24;
 import 'package:stadata_flutter_sdk/src/core/storage/secure_storage_impl.dart'
-    as _i21;
+    as _i25;
 import 'package:stadata_flutter_sdk/src/features/domains/data/datasources/domain_remote_data_source.dart'
     as _i3;
 import 'package:stadata_flutter_sdk/src/features/domains/data/repositories/domain_repository_impl.dart'
@@ -34,55 +34,81 @@ import 'package:stadata_flutter_sdk/src/features/domains/data/repositories/domai
 import 'package:stadata_flutter_sdk/src/features/domains/domain/repositories/domain_repository.dart'
     as _i4;
 import 'package:stadata_flutter_sdk/src/features/domains/domain/usecases/get_domains.dart'
-    as _i15;
-import 'package:stadata_flutter_sdk/src/features/infographics/data/datasources/infographic_remote_data_source.dart'
-    as _i17;
-import 'package:stadata_flutter_sdk/src/features/infographics/data/repositories/infographic_repository_impl.dart'
     as _i19;
+import 'package:stadata_flutter_sdk/src/features/infographics/data/datasources/infographic_remote_data_source.dart'
+    as _i21;
+import 'package:stadata_flutter_sdk/src/features/infographics/data/repositories/infographic_repository_impl.dart'
+    as _i23;
 import 'package:stadata_flutter_sdk/src/features/infographics/domain/repositories/infographic_repository.dart'
-    as _i18;
+    as _i22;
 import 'package:stadata_flutter_sdk/src/features/infographics/domain/usecases/get_all_infographics.dart'
     as _i7;
 import 'package:stadata_flutter_sdk/src/features/news/data/datasources/news_remote_data_source.dart'
-    as _i27;
+    as _i31;
 import 'package:stadata_flutter_sdk/src/features/news/data/repositories/news_repository_impl.dart'
-    as _i29;
+    as _i33;
 import 'package:stadata_flutter_sdk/src/features/news/domain/repositories/news_repository.dart'
-    as _i28;
+    as _i32;
 import 'package:stadata_flutter_sdk/src/features/news/domain/usecases/get_all_news.dart'
     as _i8;
 import 'package:stadata_flutter_sdk/src/features/news/domain/usecases/get_detail_news.dart'
-    as _i12;
+    as _i15;
 import 'package:stadata_flutter_sdk/src/features/news_categories/data/datasources/news_category_remote_data_source.dart'
-    as _i24;
+    as _i28;
 import 'package:stadata_flutter_sdk/src/features/news_categories/data/repositories/news_category_repository_impl.dart'
-    as _i26;
+    as _i30;
 import 'package:stadata_flutter_sdk/src/features/news_categories/domain/respositories/news_category_repository.dart'
-    as _i25;
+    as _i29;
 import 'package:stadata_flutter_sdk/src/features/news_categories/domain/usecases/get_all_news_categories.dart'
     as _i9;
-import 'package:stadata_flutter_sdk/src/features/publications/data/datasources/publication_remote_data_source.dart'
-    as _i30;
-import 'package:stadata_flutter_sdk/src/features/publications/data/repositories/publication_repository_impl.dart'
-    as _i32;
-import 'package:stadata_flutter_sdk/src/features/publications/domain/repositories/publication_repository.dart'
-    as _i31;
-import 'package:stadata_flutter_sdk/src/features/publications/domain/usecases/get_all_publication.dart'
+import 'package:stadata_flutter_sdk/src/features/press_releases/data/datasources/press_release_remote_data_source.dart'
+    as _i34;
+import 'package:stadata_flutter_sdk/src/features/press_releases/data/repositories/press_release_repository_impl.dart'
+    as _i36;
+import 'package:stadata_flutter_sdk/src/features/press_releases/domain/repositories/press_release_repository.dart'
+    as _i35;
+import 'package:stadata_flutter_sdk/src/features/press_releases/domain/usecases/get_all_press_releases.dart'
     as _i10;
-import 'package:stadata_flutter_sdk/src/features/publications/domain/usecases/get_detail_publication.dart'
-    as _i13;
-import 'package:stadata_flutter_sdk/src/features/static_tables/data/datasources/static_table_remote_data_source.dart'
-    as _i38;
-import 'package:stadata_flutter_sdk/src/features/static_tables/data/repositories/static_table_repository_impl.dart'
-    as _i40;
-import 'package:stadata_flutter_sdk/src/features/static_tables/domain/repositories/static_table_repository.dart'
+import 'package:stadata_flutter_sdk/src/features/press_releases/domain/usecases/get_detail_press_release.dart'
+    as _i16;
+import 'package:stadata_flutter_sdk/src/features/publications/data/datasources/publication_remote_data_source.dart'
+    as _i37;
+import 'package:stadata_flutter_sdk/src/features/publications/data/repositories/publication_repository_impl.dart'
     as _i39;
-import 'package:stadata_flutter_sdk/src/features/static_tables/domain/usecases/get_all_static_tables.dart'
+import 'package:stadata_flutter_sdk/src/features/publications/domain/repositories/publication_repository.dart'
+    as _i38;
+import 'package:stadata_flutter_sdk/src/features/publications/domain/usecases/get_all_publication.dart'
     as _i11;
+import 'package:stadata_flutter_sdk/src/features/publications/domain/usecases/get_detail_publication.dart'
+    as _i17;
+import 'package:stadata_flutter_sdk/src/features/static_tables/data/datasources/static_table_remote_data_source.dart'
+    as _i45;
+import 'package:stadata_flutter_sdk/src/features/static_tables/data/repositories/static_table_repository_impl.dart'
+    as _i47;
+import 'package:stadata_flutter_sdk/src/features/static_tables/domain/repositories/static_table_repository.dart'
+    as _i46;
+import 'package:stadata_flutter_sdk/src/features/static_tables/domain/usecases/get_all_static_tables.dart'
+    as _i12;
 import 'package:stadata_flutter_sdk/src/features/static_tables/domain/usecases/get_detail_static_table.dart'
+    as _i18;
+import 'package:stadata_flutter_sdk/src/features/subject_categories/data/datasources/subject_category_remote_data_source.dart'
+    as _i48;
+import 'package:stadata_flutter_sdk/src/features/subject_categories/data/repositories/subject_category_repository_impl.dart'
+    as _i50;
+import 'package:stadata_flutter_sdk/src/features/subject_categories/domain/repositories/subject_category_repository.dart'
+    as _i49;
+import 'package:stadata_flutter_sdk/src/features/subject_categories/domain/usecases/get_all_subject_categories.dart'
+    as _i13;
+import 'package:stadata_flutter_sdk/src/features/subjects/data/datasources/subject_remote_data_source.dart'
+    as _i51;
+import 'package:stadata_flutter_sdk/src/features/subjects/data/repositories/subject_repository_impl.dart'
+    as _i53;
+import 'package:stadata_flutter_sdk/src/features/subjects/domain/repositories/subject_repository.dart'
+    as _i52;
+import 'package:stadata_flutter_sdk/src/features/subjects/domain/usecases/get_all_subjects.dart'
     as _i14;
-import 'package:stadata_flutter_sdk/src/list/list.dart' as _i34;
-import 'package:stadata_flutter_sdk/src/view/view.dart' as _i36;
+import 'package:stadata_flutter_sdk/src/list/list.dart' as _i41;
+import 'package:stadata_flutter_sdk/src/view/view.dart' as _i43;
 
 // initializes the registration of main-scope dependencies inside of GetIt
 _i1.GetIt $initGetIt(
@@ -103,56 +129,73 @@ _i1.GetIt $initGetIt(
   gh.lazySingleton<_i7.GetAllInfographics>(() => _i7.GetAllInfographics());
   gh.lazySingleton<_i8.GetAllNews>(() => _i8.GetAllNews());
   gh.lazySingleton<_i9.GetAllNewsCategories>(() => _i9.GetAllNewsCategories());
-  gh.lazySingleton<_i10.GetAllPublication>(() => _i10.GetAllPublication());
-  gh.lazySingleton<_i11.GetAllStaticTables>(() => _i11.GetAllStaticTables());
-  gh.lazySingleton<_i12.GetDetailNews>(() => _i12.GetDetailNews());
-  gh.lazySingleton<_i13.GetDetailPublication>(
-      () => _i13.GetDetailPublication());
-  gh.lazySingleton<_i14.GetDetailStaticTable>(
-      () => _i14.GetDetailStaticTable());
-  gh.lazySingleton<_i15.GetDomains>(() => _i15.GetDomains());
-  gh.factory<_i16.HttpClient>(() => registerModule.httpClient);
-  gh.factory<_i16.HttpClient>(
+  gh.lazySingleton<_i10.GetAllPressReleases>(() => _i10.GetAllPressReleases());
+  gh.lazySingleton<_i11.GetAllPublication>(() => _i11.GetAllPublication());
+  gh.lazySingleton<_i12.GetAllStaticTables>(() => _i12.GetAllStaticTables());
+  gh.lazySingleton<_i13.GetAllSubjectCategories>(
+      () => _i13.GetAllSubjectCategories());
+  gh.lazySingleton<_i14.GetAllSubjects>(() => _i14.GetAllSubjects());
+  gh.lazySingleton<_i15.GetDetailNews>(() => _i15.GetDetailNews());
+  gh.lazySingleton<_i16.GetDetailPressRelease>(
+      () => _i16.GetDetailPressRelease());
+  gh.lazySingleton<_i17.GetDetailPublication>(
+      () => _i17.GetDetailPublication());
+  gh.lazySingleton<_i18.GetDetailStaticTable>(
+      () => _i18.GetDetailStaticTable());
+  gh.lazySingleton<_i19.GetDomains>(() => _i19.GetDomains());
+  gh.factory<_i20.HttpClient>(() => registerModule.httpClient);
+  gh.factory<_i20.HttpClient>(
     () => registerModule.listHttpClient,
     instanceName: 'listClient',
   );
-  gh.factory<_i16.HttpClient>(
+  gh.factory<_i20.HttpClient>(
     () => registerModule.viewHttpClient,
     instanceName: 'viewClient',
   );
-  gh.lazySingleton<_i17.InfographicRemoteDataSource>(
-      () => _i17.InfographicRemoteDataSourceImpl());
-  gh.lazySingleton<_i18.InfographicRepository>(
-      () => _i19.InfographicRepositoryImpl());
-  gh.lazySingleton<_i20.LocalStorage>(
-    () => _i21.SecureStorageImpl(),
+  gh.lazySingleton<_i21.InfographicRemoteDataSource>(
+      () => _i21.InfographicRemoteDataSourceImpl());
+  gh.lazySingleton<_i22.InfographicRepository>(
+      () => _i23.InfographicRepositoryImpl());
+  gh.lazySingleton<_i24.LocalStorage>(
+    () => _i25.SecureStorageImpl(),
     instanceName: 'secure',
   );
-  gh.lazySingleton<_i22.Log>(() => _i22.Log());
-  gh.factory<_i23.Logger>(() => registerModule.logger);
-  gh.lazySingleton<_i24.NewsCategoryRemoteDataSource>(
-      () => _i24.NewsCategoryRemoteDataSourceImpl());
-  gh.lazySingleton<_i25.NewsCategoryRepository>(
-      () => _i26.NewsCategoryRepositoryImpl());
-  gh.lazySingleton<_i27.NewsRemoteDataSource>(
-      () => _i27.NewsRemoteDataSourceImpl());
-  gh.lazySingleton<_i28.NewsRepository>(() => _i29.NewsRepositoryImpl());
-  gh.lazySingleton<_i30.PublicationRemoteDataSource>(
-      () => _i30.PublicationRemoteDataSourceImpl());
-  gh.lazySingleton<_i31.PublicationRepository>(
-      () => _i32.PublicationRepositoryImpl());
-  gh.lazySingleton<_i33.StadataHttpModule>(() => _i33.StadataHttpModule());
-  gh.lazySingleton<_i34.StadataList>(() => _i34.StadataListImpl());
-  gh.lazySingleton<_i35.StadataListHttpModule>(
-      () => _i35.StadataListHttpModule());
-  gh.lazySingleton<_i36.StadataView>(() => _i36.StadataViewImpl());
-  gh.lazySingleton<_i37.StadataViewHttpModule>(
-      () => _i37.StadataViewHttpModule());
-  gh.lazySingleton<_i38.StaticTableRemoteDataSource>(
-      () => _i38.StaticTableRemoteDataSourceImpl());
-  gh.lazySingleton<_i39.StaticTableRepository>(
-      () => _i40.StaticTableRepositoryImpl());
+  gh.lazySingleton<_i26.Log>(() => _i26.Log());
+  gh.factory<_i27.Logger>(() => registerModule.logger);
+  gh.lazySingleton<_i28.NewsCategoryRemoteDataSource>(
+      () => _i28.NewsCategoryRemoteDataSourceImpl());
+  gh.lazySingleton<_i29.NewsCategoryRepository>(
+      () => _i30.NewsCategoryRepositoryImpl());
+  gh.lazySingleton<_i31.NewsRemoteDataSource>(
+      () => _i31.NewsRemoteDataSourceImpl());
+  gh.lazySingleton<_i32.NewsRepository>(() => _i33.NewsRepositoryImpl());
+  gh.lazySingleton<_i34.PressReleaseRemoteDataSource>(
+      () => _i34.PressReleaseRemoteDataSourceImpl());
+  gh.lazySingleton<_i35.PressReleaseRepository>(
+      () => _i36.PressReleaseRepositoryImpl());
+  gh.lazySingleton<_i37.PublicationRemoteDataSource>(
+      () => _i37.PublicationRemoteDataSourceImpl());
+  gh.lazySingleton<_i38.PublicationRepository>(
+      () => _i39.PublicationRepositoryImpl());
+  gh.lazySingleton<_i40.StadataHttpModule>(() => _i40.StadataHttpModule());
+  gh.lazySingleton<_i41.StadataList>(() => _i41.StadataListImpl());
+  gh.lazySingleton<_i42.StadataListHttpModule>(
+      () => _i42.StadataListHttpModule());
+  gh.lazySingleton<_i43.StadataView>(() => _i43.StadataViewImpl());
+  gh.lazySingleton<_i44.StadataViewHttpModule>(
+      () => _i44.StadataViewHttpModule());
+  gh.lazySingleton<_i45.StaticTableRemoteDataSource>(
+      () => _i45.StaticTableRemoteDataSourceImpl());
+  gh.lazySingleton<_i46.StaticTableRepository>(
+      () => _i47.StaticTableRepositoryImpl());
+  gh.lazySingleton<_i48.SubjectCategoryRemoteDataSource>(
+      () => _i48.SubjectCategoryRemoteDataSourceImpl());
+  gh.lazySingleton<_i49.SubjectCategoryRepository>(
+      () => _i50.SubjectCategoryRepositoryImpl());
+  gh.lazySingleton<_i51.SubjectRemoteDataSource>(
+      () => _i51.SubjectModelRemoteDataSourceImpl());
+  gh.lazySingleton<_i52.SubjectRepository>(() => _i53.SubjectRepositoryImpl());
   return getIt;
 }
 
-class _$RegisterModule extends _i41.RegisterModule {}
+class _$RegisterModule extends _i54.RegisterModule {}

--- a/lib/src/core/exceptions/exceptions.dart
+++ b/lib/src/core/exceptions/exceptions.dart
@@ -89,3 +89,39 @@ class NewsCategoryNotAvailableException extends NewsCategoryException {
     super.message = 'News Category not available!',
   });
 }
+
+class SubjectCategoryException extends StadataException {
+  const SubjectCategoryException({
+    super.message = 'There is something wrong with Subject Category data!',
+  });
+}
+
+class SubjectCategoryNotAvailableException extends SubjectCategoryException {
+  const SubjectCategoryNotAvailableException({
+    super.message = 'Subject Category not available!',
+  });
+}
+
+class SubjectException extends StadataException {
+  const SubjectException({
+    super.message = 'There is something wrong with Subject data!',
+  });
+}
+
+class SubjectNotAvailableException extends SubjectCategoryException {
+  const SubjectNotAvailableException({
+    super.message = 'Subject not available!',
+  });
+}
+
+class PressReleaseException extends StadataException {
+  const PressReleaseException({
+    super.message = 'There is something wrong with Press Release data!',
+  });
+}
+
+class PressReleaseNotAvailableException extends SubjectCategoryException {
+  const PressReleaseNotAvailableException({
+    super.message = 'Press Release not available!',
+  });
+}

--- a/lib/src/core/failures/failures.dart
+++ b/lib/src/core/failures/failures.dart
@@ -51,3 +51,21 @@ class NewsCategoryFailure extends Failure {
     super.message = 'Failed to load news category data!',
   });
 }
+
+class SubjectCategoryFailure extends Failure {
+  const SubjectCategoryFailure({
+    super.message = 'Failed to load subject category data!',
+  });
+}
+
+class SubjectFailure extends Failure {
+  const SubjectFailure({
+    super.message = 'Failed to load subject data!',
+  });
+}
+
+class PressReleaseFailure extends Failure {
+  const PressReleaseFailure({
+    super.message = 'Failed to load press release data!',
+  });
+}

--- a/lib/src/core/network/api_endpoint.dart
+++ b/lib/src/core/network/api_endpoint.dart
@@ -152,4 +152,62 @@ class ApiEndpoint {
     DataLanguage lang = DataLanguage.id,
   }) =>
       'model/newscategory?domain=$domain&lang=${lang.value}';
+
+  static String subjectCategories({
+    required String domain,
+    DataLanguage lang = DataLanguage.id,
+    int page = 1,
+  }) =>
+      'model/subcat?page=$page&domain=$domain&lang=${lang.value}';
+
+  static String subjects({
+    required String domain,
+    int? subjectCategoryId,
+    DataLanguage lang = DataLanguage.id,
+    int page = 1,
+  }) {
+    final path = StringBuffer(
+      'model/subject?domain=$domain&lang=${lang.value}&page=$page',
+    );
+
+    if (subjectCategoryId != null) {
+      path.write('&subcat=$subjectCategoryId');
+    }
+
+    return path.toString();
+  }
+
+  static String pressReleases({
+    required String domain,
+    int page = 1,
+    DataLanguage lang = DataLanguage.id,
+    int? month,
+    int? year,
+    String? keyword,
+  }) {
+    final path = StringBuffer(
+      'model/pressrelease?domain=$domain&page=$page&lang=${lang.value}',
+    );
+
+    if (month != null) {
+      path.write('&month=${month.toString().padLeft(2, '0')}');
+    }
+
+    if (year != null) {
+      path.write('&year=$year');
+    }
+
+    if (keyword != null && keyword.isNotEmpty) {
+      path.write('&keyword=$keyword');
+    }
+
+    return path.toString();
+  }
+
+  static String pressReleaseDetail({
+    required int id,
+    required String domain,
+    DataLanguage lang = DataLanguage.id,
+  }) =>
+      'model/pressrelease?id=$id&domain=$domain&lang=${lang.value}';
 }

--- a/lib/src/features/features.dart
+++ b/lib/src/features/features.dart
@@ -2,5 +2,8 @@ export './domains/domains.dart';
 export './infographics/infographics.dart';
 export './news/news.dart';
 export './news_categories/news_categories.dart';
+export './press_releases/press_releases.dart';
 export './publications/publications.dart';
 export './static_tables/static_tables.dart';
+export './subject_categories/subject_categories.dart';
+export './subjects/subjects.dart';

--- a/lib/src/features/press_releases/data/datasources/press_release_remote_data_source.dart
+++ b/lib/src/features/press_releases/data/datasources/press_release_remote_data_source.dart
@@ -1,0 +1,109 @@
+// ignore_for_file: public_member_api_docs
+
+import 'package:injectable/injectable.dart';
+import 'package:stadata_flutter_sdk/src/core/di/service_locator.dart';
+import 'package:stadata_flutter_sdk/src/core/network/api_endpoint.dart';
+import 'package:stadata_flutter_sdk/src/core/network/http/modules/stadata_list_http_module.dart';
+import 'package:stadata_flutter_sdk/src/core/network/http/modules/stadata_view_http_module.dart';
+import 'package:stadata_flutter_sdk/src/core/typedef/typedef.dart';
+import 'package:stadata_flutter_sdk/src/features/press_releases/data/models/press_release_model.dart';
+import 'package:stadata_flutter_sdk/src/shared/data/models/api_response_model.dart';
+import 'package:stadata_flutter_sdk/stadata_flutter_sdk.dart';
+
+abstract class PressReleaseRemoteDataSource {
+  Future<ApiResponseModel<List<PressReleaseModel>?>> get({
+    required String domain,
+    DataLanguage lang = DataLanguage.id,
+    int page = 1,
+    String? newsCategoryId,
+    int? month,
+    int? year,
+    String? keyword,
+  });
+  Future<ApiResponseModel<PressReleaseModel?>> detail({
+    required int id,
+    required String domain,
+    DataLanguage lang = DataLanguage.id,
+  });
+}
+
+@LazySingleton(as: PressReleaseRemoteDataSource)
+class PressReleaseRemoteDataSourceImpl implements PressReleaseRemoteDataSource {
+  final _listClient = getIt<StadataListHttpModule>();
+  final _detailClient = getIt<StadataViewHttpModule>();
+
+  @override
+  Future<ApiResponseModel<PressReleaseModel?>> detail({
+    required int id,
+    required String domain,
+    DataLanguage lang = DataLanguage.id,
+  }) async {
+    final result = await _detailClient.get(
+      ApiEndpoint.pressReleaseDetail(
+        id: id,
+        lang: lang,
+        domain: domain,
+      ),
+    );
+
+    final response = ApiResponseModel<PressReleaseModel?>.fromJson(
+      result,
+      (json) {
+        if (json == null) {
+          return null;
+        }
+
+        return PressReleaseModel.fromJson(json as JSON);
+      },
+    );
+
+    if (response.dataAvailability == DataAvailability.notAvailable) {
+      throw const PressReleaseNotAvailableException();
+    }
+
+    return response;
+  }
+
+  @override
+  Future<ApiResponseModel<List<PressReleaseModel>?>> get({
+    required String domain,
+    DataLanguage lang = DataLanguage.id,
+    int page = 1,
+    String? newsCategoryId,
+    int? month,
+    int? year,
+    String? keyword,
+  }) async {
+    final result = await _listClient.get(
+      ApiEndpoint.pressReleases(
+        page: page,
+        lang: lang,
+        year: year,
+        month: month,
+        domain: domain,
+        keyword: keyword,
+      ),
+    );
+
+    final response = ApiResponseModel<List<PressReleaseModel>?>.fromJson(
+      result,
+      (json) {
+        if (json == null) {
+          return null;
+        }
+
+        if (json is! List) {
+          return null;
+        }
+
+        return json.map((e) => PressReleaseModel.fromJson(e as JSON)).toList();
+      },
+    );
+
+    if (response.dataAvailability == DataAvailability.listNotAvailable) {
+      throw const PressReleaseNotAvailableException();
+    }
+
+    return response;
+  }
+}

--- a/lib/src/features/press_releases/data/models/press_release_model.dart
+++ b/lib/src/features/press_releases/data/models/press_release_model.dart
@@ -1,0 +1,53 @@
+// ignore_for_file: public_member_api_docs
+
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:stadata_flutter_sdk/src/features/press_releases/data/serializers/abstract_serializer.dart';
+import 'package:stadata_flutter_sdk/src/features/subjects/data/models/subject_model.dart';
+import 'package:stadata_flutter_sdk/stadata_flutter_sdk.dart';
+
+part 'press_release_model.freezed.dart';
+part 'press_release_model.g.dart';
+
+@freezed
+abstract class PressReleaseModel with _$PressReleaseModel {
+  factory PressReleaseModel({
+    @JsonKey(name: 'brs_id') required int id,
+    @JsonKey(name: 'subj', readValue: _subjectValueReader)
+    SubjectModel? subject,
+    required String title,
+    @AbstractSerializer() required String abstract,
+    @JsonKey(name: 'rl_date') required DateTime releaseDate,
+    required String pdf,
+    required String slide,
+    required String size,
+    @JsonKey(name: 'thumbnail') required String cover,
+    @JsonKey(name: 'updt_date') DateTime? updatedAt,
+  }) = _PressReleaseModel;
+  factory PressReleaseModel.fromJson(Map<String, dynamic> json) =>
+      _$PressReleaseModelFromJson(json);
+}
+
+Object? _subjectValueReader(Map<dynamic, dynamic> json, String key) {
+  if (json['subj'] == null || json['subj_id'] == null) {
+    return null;
+  }
+
+  return SubjectModel(
+    id: json['subj_id'] as int,
+    name: json['subj'] as String,
+  ).toJson();
+}
+
+extension PressReleaseModelX on PressReleaseModel {
+  PressRelease toEntity() => PressRelease(
+        id: id,
+        subject: subject?.toEntity(),
+        title: title,
+        abstract: abstract,
+        releaseDate: releaseDate,
+        pdf: pdf,
+        size: size,
+        cover: cover,
+        slide: slide,
+      );
+}

--- a/lib/src/features/press_releases/data/models/press_release_model.dart
+++ b/lib/src/features/press_releases/data/models/press_release_model.dart
@@ -12,8 +12,6 @@ part 'press_release_model.g.dart';
 abstract class PressReleaseModel with _$PressReleaseModel {
   factory PressReleaseModel({
     @JsonKey(name: 'brs_id') required int id,
-    @JsonKey(name: 'subj', readValue: _subjectValueReader)
-    SubjectModel? subject,
     required String title,
     @AbstractSerializer() required String abstract,
     @JsonKey(name: 'rl_date') required DateTime releaseDate,
@@ -21,6 +19,8 @@ abstract class PressReleaseModel with _$PressReleaseModel {
     required String slide,
     required String size,
     @JsonKey(name: 'thumbnail') required String cover,
+    @JsonKey(name: 'subj', readValue: _subjectValueReader)
+    SubjectModel? subject,
     @JsonKey(name: 'updt_date') DateTime? updatedAt,
   }) = _PressReleaseModel;
   factory PressReleaseModel.fromJson(Map<String, dynamic> json) =>

--- a/lib/src/features/press_releases/data/models/press_release_model.freezed.dart
+++ b/lib/src/features/press_releases/data/models/press_release_model.freezed.dart
@@ -1,0 +1,379 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'press_release_model.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#custom-getters-and-methods');
+
+PressReleaseModel _$PressReleaseModelFromJson(Map<String, dynamic> json) {
+  return _PressReleaseModel.fromJson(json);
+}
+
+/// @nodoc
+mixin _$PressReleaseModel {
+  @JsonKey(name: 'brs_id')
+  int get id => throw _privateConstructorUsedError;
+  @JsonKey(name: 'subj', readValue: _subjectValueReader)
+  SubjectModel? get subject => throw _privateConstructorUsedError;
+  String get title => throw _privateConstructorUsedError;
+  @AbstractSerializer()
+  String get abstract => throw _privateConstructorUsedError;
+  @JsonKey(name: 'rl_date')
+  DateTime get releaseDate => throw _privateConstructorUsedError;
+  String get pdf => throw _privateConstructorUsedError;
+  String get slide => throw _privateConstructorUsedError;
+  String get size => throw _privateConstructorUsedError;
+  @JsonKey(name: 'thumbnail')
+  String get cover => throw _privateConstructorUsedError;
+  @JsonKey(name: 'updt_date')
+  DateTime? get updatedAt => throw _privateConstructorUsedError;
+
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+  @JsonKey(ignore: true)
+  $PressReleaseModelCopyWith<PressReleaseModel> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $PressReleaseModelCopyWith<$Res> {
+  factory $PressReleaseModelCopyWith(
+          PressReleaseModel value, $Res Function(PressReleaseModel) then) =
+      _$PressReleaseModelCopyWithImpl<$Res, PressReleaseModel>;
+  @useResult
+  $Res call(
+      {@JsonKey(name: 'brs_id') int id,
+      @JsonKey(name: 'subj', readValue: _subjectValueReader)
+      SubjectModel? subject,
+      String title,
+      @AbstractSerializer() String abstract,
+      @JsonKey(name: 'rl_date') DateTime releaseDate,
+      String pdf,
+      String slide,
+      String size,
+      @JsonKey(name: 'thumbnail') String cover,
+      @JsonKey(name: 'updt_date') DateTime? updatedAt});
+
+  $SubjectModelCopyWith<$Res>? get subject;
+}
+
+/// @nodoc
+class _$PressReleaseModelCopyWithImpl<$Res, $Val extends PressReleaseModel>
+    implements $PressReleaseModelCopyWith<$Res> {
+  _$PressReleaseModelCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? id = null,
+    Object? subject = freezed,
+    Object? title = null,
+    Object? abstract = null,
+    Object? releaseDate = null,
+    Object? pdf = null,
+    Object? slide = null,
+    Object? size = null,
+    Object? cover = null,
+    Object? updatedAt = freezed,
+  }) {
+    return _then(_value.copyWith(
+      id: null == id
+          ? _value.id
+          : id // ignore: cast_nullable_to_non_nullable
+              as int,
+      subject: freezed == subject
+          ? _value.subject
+          : subject // ignore: cast_nullable_to_non_nullable
+              as SubjectModel?,
+      title: null == title
+          ? _value.title
+          : title // ignore: cast_nullable_to_non_nullable
+              as String,
+      abstract: null == abstract
+          ? _value.abstract
+          : abstract // ignore: cast_nullable_to_non_nullable
+              as String,
+      releaseDate: null == releaseDate
+          ? _value.releaseDate
+          : releaseDate // ignore: cast_nullable_to_non_nullable
+              as DateTime,
+      pdf: null == pdf
+          ? _value.pdf
+          : pdf // ignore: cast_nullable_to_non_nullable
+              as String,
+      slide: null == slide
+          ? _value.slide
+          : slide // ignore: cast_nullable_to_non_nullable
+              as String,
+      size: null == size
+          ? _value.size
+          : size // ignore: cast_nullable_to_non_nullable
+              as String,
+      cover: null == cover
+          ? _value.cover
+          : cover // ignore: cast_nullable_to_non_nullable
+              as String,
+      updatedAt: freezed == updatedAt
+          ? _value.updatedAt
+          : updatedAt // ignore: cast_nullable_to_non_nullable
+              as DateTime?,
+    ) as $Val);
+  }
+
+  @override
+  @pragma('vm:prefer-inline')
+  $SubjectModelCopyWith<$Res>? get subject {
+    if (_value.subject == null) {
+      return null;
+    }
+
+    return $SubjectModelCopyWith<$Res>(_value.subject!, (value) {
+      return _then(_value.copyWith(subject: value) as $Val);
+    });
+  }
+}
+
+/// @nodoc
+abstract class _$$_PressReleaseModelCopyWith<$Res>
+    implements $PressReleaseModelCopyWith<$Res> {
+  factory _$$_PressReleaseModelCopyWith(_$_PressReleaseModel value,
+          $Res Function(_$_PressReleaseModel) then) =
+      __$$_PressReleaseModelCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call(
+      {@JsonKey(name: 'brs_id') int id,
+      @JsonKey(name: 'subj', readValue: _subjectValueReader)
+      SubjectModel? subject,
+      String title,
+      @AbstractSerializer() String abstract,
+      @JsonKey(name: 'rl_date') DateTime releaseDate,
+      String pdf,
+      String slide,
+      String size,
+      @JsonKey(name: 'thumbnail') String cover,
+      @JsonKey(name: 'updt_date') DateTime? updatedAt});
+
+  @override
+  $SubjectModelCopyWith<$Res>? get subject;
+}
+
+/// @nodoc
+class __$$_PressReleaseModelCopyWithImpl<$Res>
+    extends _$PressReleaseModelCopyWithImpl<$Res, _$_PressReleaseModel>
+    implements _$$_PressReleaseModelCopyWith<$Res> {
+  __$$_PressReleaseModelCopyWithImpl(
+      _$_PressReleaseModel _value, $Res Function(_$_PressReleaseModel) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? id = null,
+    Object? subject = freezed,
+    Object? title = null,
+    Object? abstract = null,
+    Object? releaseDate = null,
+    Object? pdf = null,
+    Object? slide = null,
+    Object? size = null,
+    Object? cover = null,
+    Object? updatedAt = freezed,
+  }) {
+    return _then(_$_PressReleaseModel(
+      id: null == id
+          ? _value.id
+          : id // ignore: cast_nullable_to_non_nullable
+              as int,
+      subject: freezed == subject
+          ? _value.subject
+          : subject // ignore: cast_nullable_to_non_nullable
+              as SubjectModel?,
+      title: null == title
+          ? _value.title
+          : title // ignore: cast_nullable_to_non_nullable
+              as String,
+      abstract: null == abstract
+          ? _value.abstract
+          : abstract // ignore: cast_nullable_to_non_nullable
+              as String,
+      releaseDate: null == releaseDate
+          ? _value.releaseDate
+          : releaseDate // ignore: cast_nullable_to_non_nullable
+              as DateTime,
+      pdf: null == pdf
+          ? _value.pdf
+          : pdf // ignore: cast_nullable_to_non_nullable
+              as String,
+      slide: null == slide
+          ? _value.slide
+          : slide // ignore: cast_nullable_to_non_nullable
+              as String,
+      size: null == size
+          ? _value.size
+          : size // ignore: cast_nullable_to_non_nullable
+              as String,
+      cover: null == cover
+          ? _value.cover
+          : cover // ignore: cast_nullable_to_non_nullable
+              as String,
+      updatedAt: freezed == updatedAt
+          ? _value.updatedAt
+          : updatedAt // ignore: cast_nullable_to_non_nullable
+              as DateTime?,
+    ));
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$_PressReleaseModel implements _PressReleaseModel {
+  _$_PressReleaseModel(
+      {@JsonKey(name: 'brs_id') required this.id,
+      @JsonKey(name: 'subj', readValue: _subjectValueReader) this.subject,
+      required this.title,
+      @AbstractSerializer() required this.abstract,
+      @JsonKey(name: 'rl_date') required this.releaseDate,
+      required this.pdf,
+      required this.slide,
+      required this.size,
+      @JsonKey(name: 'thumbnail') required this.cover,
+      @JsonKey(name: 'updt_date') this.updatedAt});
+
+  factory _$_PressReleaseModel.fromJson(Map<String, dynamic> json) =>
+      _$$_PressReleaseModelFromJson(json);
+
+  @override
+  @JsonKey(name: 'brs_id')
+  final int id;
+  @override
+  @JsonKey(name: 'subj', readValue: _subjectValueReader)
+  final SubjectModel? subject;
+  @override
+  final String title;
+  @override
+  @AbstractSerializer()
+  final String abstract;
+  @override
+  @JsonKey(name: 'rl_date')
+  final DateTime releaseDate;
+  @override
+  final String pdf;
+  @override
+  final String slide;
+  @override
+  final String size;
+  @override
+  @JsonKey(name: 'thumbnail')
+  final String cover;
+  @override
+  @JsonKey(name: 'updt_date')
+  final DateTime? updatedAt;
+
+  @override
+  String toString() {
+    return 'PressReleaseModel(id: $id, subject: $subject, title: $title, abstract: $abstract, releaseDate: $releaseDate, pdf: $pdf, slide: $slide, size: $size, cover: $cover, updatedAt: $updatedAt)';
+  }
+
+  @override
+  bool operator ==(dynamic other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$_PressReleaseModel &&
+            (identical(other.id, id) || other.id == id) &&
+            (identical(other.subject, subject) || other.subject == subject) &&
+            (identical(other.title, title) || other.title == title) &&
+            (identical(other.abstract, abstract) ||
+                other.abstract == abstract) &&
+            (identical(other.releaseDate, releaseDate) ||
+                other.releaseDate == releaseDate) &&
+            (identical(other.pdf, pdf) || other.pdf == pdf) &&
+            (identical(other.slide, slide) || other.slide == slide) &&
+            (identical(other.size, size) || other.size == size) &&
+            (identical(other.cover, cover) || other.cover == cover) &&
+            (identical(other.updatedAt, updatedAt) ||
+                other.updatedAt == updatedAt));
+  }
+
+  @JsonKey(ignore: true)
+  @override
+  int get hashCode => Object.hash(runtimeType, id, subject, title, abstract,
+      releaseDate, pdf, slide, size, cover, updatedAt);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$_PressReleaseModelCopyWith<_$_PressReleaseModel> get copyWith =>
+      __$$_PressReleaseModelCopyWithImpl<_$_PressReleaseModel>(
+          this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$_PressReleaseModelToJson(
+      this,
+    );
+  }
+}
+
+abstract class _PressReleaseModel implements PressReleaseModel {
+  factory _PressReleaseModel(
+          {@JsonKey(name: 'brs_id') required final int id,
+          @JsonKey(name: 'subj', readValue: _subjectValueReader)
+          final SubjectModel? subject,
+          required final String title,
+          @AbstractSerializer() required final String abstract,
+          @JsonKey(name: 'rl_date') required final DateTime releaseDate,
+          required final String pdf,
+          required final String slide,
+          required final String size,
+          @JsonKey(name: 'thumbnail') required final String cover,
+          @JsonKey(name: 'updt_date') final DateTime? updatedAt}) =
+      _$_PressReleaseModel;
+
+  factory _PressReleaseModel.fromJson(Map<String, dynamic> json) =
+      _$_PressReleaseModel.fromJson;
+
+  @override
+  @JsonKey(name: 'brs_id')
+  int get id;
+  @override
+  @JsonKey(name: 'subj', readValue: _subjectValueReader)
+  SubjectModel? get subject;
+  @override
+  String get title;
+  @override
+  @AbstractSerializer()
+  String get abstract;
+  @override
+  @JsonKey(name: 'rl_date')
+  DateTime get releaseDate;
+  @override
+  String get pdf;
+  @override
+  String get slide;
+  @override
+  String get size;
+  @override
+  @JsonKey(name: 'thumbnail')
+  String get cover;
+  @override
+  @JsonKey(name: 'updt_date')
+  DateTime? get updatedAt;
+  @override
+  @JsonKey(ignore: true)
+  _$$_PressReleaseModelCopyWith<_$_PressReleaseModel> get copyWith =>
+      throw _privateConstructorUsedError;
+}

--- a/lib/src/features/press_releases/data/models/press_release_model.g.dart
+++ b/lib/src/features/press_releases/data/models/press_release_model.g.dart
@@ -1,0 +1,41 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'press_release_model.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_$_PressReleaseModel _$$_PressReleaseModelFromJson(Map<String, dynamic> json) =>
+    _$_PressReleaseModel(
+      id: json['brs_id'] as int,
+      subject: _subjectValueReader(json, 'subj') == null
+          ? null
+          : SubjectModel.fromJson(
+              _subjectValueReader(json, 'subj') as Map<String, dynamic>),
+      title: json['title'] as String,
+      abstract: const AbstractSerializer().fromJson(json['abstract'] as String),
+      releaseDate: DateTime.parse(json['rl_date'] as String),
+      pdf: json['pdf'] as String,
+      slide: json['slide'] as String,
+      size: json['size'] as String,
+      cover: json['thumbnail'] as String,
+      updatedAt: json['updt_date'] == null
+          ? null
+          : DateTime.parse(json['updt_date'] as String),
+    );
+
+Map<String, dynamic> _$$_PressReleaseModelToJson(
+        _$_PressReleaseModel instance) =>
+    <String, dynamic>{
+      'brs_id': instance.id,
+      'subj': instance.subject,
+      'title': instance.title,
+      'abstract': const AbstractSerializer().toJson(instance.abstract),
+      'rl_date': instance.releaseDate.toIso8601String(),
+      'pdf': instance.pdf,
+      'slide': instance.slide,
+      'size': instance.size,
+      'thumbnail': instance.cover,
+      'updt_date': instance.updatedAt?.toIso8601String(),
+    };

--- a/lib/src/features/press_releases/data/repositories/press_release_repository_impl.dart
+++ b/lib/src/features/press_releases/data/repositories/press_release_repository_impl.dart
@@ -1,0 +1,91 @@
+// ignore_for_file: public_member_api_docs
+
+import 'dart:developer';
+
+import 'package:dartz/dartz.dart';
+import 'package:injectable/injectable.dart';
+import 'package:stadata_flutter_sdk/src/core/di/service_locator.dart';
+import 'package:stadata_flutter_sdk/src/core/failures/failures.dart';
+import 'package:stadata_flutter_sdk/src/features/press_releases/data/datasources/press_release_remote_data_source.dart';
+import 'package:stadata_flutter_sdk/src/features/press_releases/data/models/press_release_model.dart';
+import 'package:stadata_flutter_sdk/src/features/press_releases/domain/repositories/press_release_repository.dart';
+import 'package:stadata_flutter_sdk/src/shared/data/models/pagination_model.dart';
+import 'package:stadata_flutter_sdk/src/shared/domain/entities/api_response.dart';
+import 'package:stadata_flutter_sdk/stadata_flutter_sdk.dart';
+
+@LazySingleton(as: PressReleaseRepository)
+class PressReleaseRepositoryImpl implements PressReleaseRepository {
+  final _remoteDataSource = getIt<PressReleaseRemoteDataSource>();
+
+  @override
+  Future<Either<Failure, ApiResponse<PressRelease>>> detail({
+    required int id,
+    required String domain,
+    DataLanguage lang = DataLanguage.id,
+  }) async {
+    try {
+      final result = await _remoteDataSource.detail(
+        id: id,
+        lang: lang,
+        domain: domain,
+      );
+
+      if (result.data == null) {
+        throw const PressReleaseNotAvailableException();
+      }
+
+      return Right(
+        ApiResponse<PressRelease>(
+          data: result.data?.toEntity(),
+          status: result.status,
+          message: result.message,
+          pagination: result.pagination?.toEntity(),
+          dataAvailability: result.dataAvailability,
+        ),
+      );
+    } catch (e) {
+      log(e.toString(), name: 'StadataException');
+      return Left(PressReleaseFailure(message: e.toString()));
+    }
+  }
+
+  @override
+  Future<Either<Failure, ApiResponse<List<PressRelease>>>> get({
+    required String domain,
+    DataLanguage lang = DataLanguage.id,
+    int page = 1,
+    int? month,
+    int? year,
+    String? keyword,
+  }) async {
+    try {
+      final result = await _remoteDataSource.get(
+        page: page,
+        lang: lang,
+        year: year,
+        month: month,
+        domain: domain,
+        keyword: keyword,
+      );
+
+      if (result.data == null) {
+        throw const NewsNotAvailableException();
+      }
+
+      final data = result.data?.map((e) => e.toEntity()).toList();
+
+      return Right(
+        ApiResponse<List<PressRelease>>(
+          data: data,
+          status: result.status,
+          message: result.message,
+          pagination: result.pagination?.toEntity(),
+          dataAvailability: result.dataAvailability,
+        ),
+      );
+    } catch (e) {
+      log(e.toString(), name: 'StadataException');
+      return Left(PressReleaseFailure(message: e.toString()));
+    }
+  }
+}

--- a/lib/src/features/press_releases/data/serializers/abstract_serializer.dart
+++ b/lib/src/features/press_releases/data/serializers/abstract_serializer.dart
@@ -1,0 +1,21 @@
+// ignore_for_file: public_member_api_docs
+
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+class AbstractSerializer extends JsonConverter<String, String> {
+  const AbstractSerializer();
+
+  @override
+  String fromJson(String json) => json
+      .replaceAll('&quot;', '"')
+      .replaceAll('quot;', '"')
+      .replaceAll('&nbsp;', '')
+      .replaceAll('&amp;', '&')
+      .replaceAll('&lt;', '<')
+      .replaceAll('&gt;', '>')
+      .replaceAll(r'\r', '')
+      .replaceAll('<nobr>', '<p>')
+      .replaceAll('</nobr>', '</p>');
+  @override
+  String toJson(String object) => object;
+}

--- a/lib/src/features/press_releases/domain/entities/press_release.dart
+++ b/lib/src/features/press_releases/domain/entities/press_release.dart
@@ -1,0 +1,81 @@
+import 'package:equatable/equatable.dart';
+import 'package:stadata_flutter_sdk/stadata_flutter_sdk.dart';
+
+/// A class representing a Press Release entity.
+///
+/// A Press Release contains information about a specific press release,
+/// including its ID, name, subject, title, abstract, release date, PDF URL,
+/// size, cover image URL, and slides URL.
+///
+/// [docs]: https://webapi.bps.go.id/documentation/#press-release
+class PressRelease extends Equatable {
+  /// Creates a [PressRelease] instance.
+  ///
+  /// [id] is the unique identifier of the press release.
+
+  /// [subject] is the associated subject of the press release.
+  /// [title] is the title of the press release.
+  /// [abstract] is a brief summary or abstract of the press release.
+  /// [releaseDate] is the date when the press release was released.
+  /// [pdf] is the URL to the PDF document of the press release.
+  /// [size] is the size of the PDF document.
+  /// [cover] is the URL to the cover image of the press release.
+  /// [slide] is the URL to the slides related to the press release.
+  /// [updatedAt] is the optional date when the press release was last updated.
+  const PressRelease({
+    required this.id,
+    required this.title,
+    required this.abstract,
+    required this.releaseDate,
+    required this.pdf,
+    required this.size,
+    required this.cover,
+    required this.slide,
+    this.subject,
+    this.updatedAt,
+  });
+
+  /// The unique identifier of the press release.
+  final int id;
+
+  /// The associated subject of the press release.
+  final Subject? subject;
+
+  /// The title of the press release.
+  final String title;
+
+  /// A brief summary or abstract of the press release.
+  final String abstract;
+
+  /// The date when the press release was released.
+  final DateTime releaseDate;
+
+  /// The date when the press release was last updated (optional).
+  final DateTime? updatedAt;
+
+  /// The URL to the PDF document of the press release.
+  final String pdf;
+
+  /// The size of the PDF document.
+  final String size;
+
+  /// The URL to the cover image of the press release.
+  final String cover;
+
+  /// The URL to the slides related to the press release.
+  final String slide;
+
+  @override
+  List<Object?> get props => [
+        id,
+        subject,
+        title,
+        abstract,
+        releaseDate,
+        updatedAt,
+        pdf,
+        size,
+        cover,
+        slide,
+      ];
+}

--- a/lib/src/features/press_releases/domain/repositories/press_release_repository.dart
+++ b/lib/src/features/press_releases/domain/repositories/press_release_repository.dart
@@ -1,0 +1,22 @@
+// ignore_for_file: public_member_api_docs
+
+import 'package:dartz/dartz.dart';
+import 'package:stadata_flutter_sdk/src/core/failures/failures.dart';
+import 'package:stadata_flutter_sdk/src/shared/domain/entities/api_response.dart';
+import 'package:stadata_flutter_sdk/stadata_flutter_sdk.dart';
+
+abstract class PressReleaseRepository {
+  Future<Either<Failure, ApiResponse<List<PressRelease>>>> get({
+    required String domain,
+    DataLanguage lang = DataLanguage.id,
+    int page = 1,
+    int? month,
+    int? year,
+    String? keyword,
+  });
+  Future<Either<Failure, ApiResponse<PressRelease>>> detail({
+    required int id,
+    required String domain,
+    DataLanguage lang = DataLanguage.id,
+  });
+}

--- a/lib/src/features/press_releases/domain/usecases/get_all_press_releases.dart
+++ b/lib/src/features/press_releases/domain/usecases/get_all_press_releases.dart
@@ -1,0 +1,55 @@
+// ignore_for_file: public_member_api_docs
+
+import 'package:dartz/dartz.dart';
+import 'package:equatable/equatable.dart';
+import 'package:injectable/injectable.dart';
+import 'package:stadata_flutter_sdk/src/base/usecase.dart';
+import 'package:stadata_flutter_sdk/src/core/di/service_locator.dart';
+import 'package:stadata_flutter_sdk/src/core/failures/failures.dart';
+import 'package:stadata_flutter_sdk/src/features/press_releases/domain/repositories/press_release_repository.dart';
+import 'package:stadata_flutter_sdk/src/shared/domain/entities/api_response.dart';
+
+import 'package:stadata_flutter_sdk/stadata_flutter_sdk.dart';
+
+@LazySingleton()
+class GetAllPressReleases
+    implements
+        UseCase<ApiResponse<List<PressRelease>>, GetAllPressReleasesParam,
+            PressReleaseRepository> {
+  @override
+  Future<Either<Failure, ApiResponse<List<PressRelease>>>> call(
+    GetAllPressReleasesParam param,
+  ) =>
+      repo.get(
+        page: param.page,
+        year: param.year,
+        lang: param.lang,
+        month: param.month,
+        domain: param.domain,
+        keyword: param.keyword,
+      );
+
+  @override
+  PressReleaseRepository get repo => getIt<PressReleaseRepository>();
+}
+
+class GetAllPressReleasesParam extends Equatable {
+  const GetAllPressReleasesParam({
+    required this.domain,
+    this.lang = DataLanguage.id,
+    this.page = 1,
+    this.month,
+    this.year,
+    this.keyword,
+  });
+
+  final String domain;
+  final DataLanguage lang;
+  final int page;
+  final int? month;
+  final int? year;
+  final String? keyword;
+
+  @override
+  List<Object?> get props => [domain, lang, page, month, year, keyword];
+}

--- a/lib/src/features/press_releases/domain/usecases/get_detail_press_release.dart
+++ b/lib/src/features/press_releases/domain/usecases/get_detail_press_release.dart
@@ -1,0 +1,46 @@
+// ignore_for_file: public_member_api_docs
+
+import 'package:dartz/dartz.dart';
+import 'package:equatable/equatable.dart';
+import 'package:injectable/injectable.dart';
+import 'package:stadata_flutter_sdk/src/base/usecase.dart';
+import 'package:stadata_flutter_sdk/src/core/di/service_locator.dart';
+import 'package:stadata_flutter_sdk/src/core/failures/failures.dart';
+import 'package:stadata_flutter_sdk/src/features/press_releases/domain/repositories/press_release_repository.dart';
+import 'package:stadata_flutter_sdk/src/shared/domain/entities/api_response.dart';
+
+import 'package:stadata_flutter_sdk/stadata_flutter_sdk.dart';
+
+@LazySingleton()
+class GetDetailPressRelease
+    implements
+        UseCase<ApiResponse<PressRelease>, GetDetailPressReleaseParam,
+            PressReleaseRepository> {
+  @override
+  Future<Either<Failure, ApiResponse<PressRelease>>> call(
+    GetDetailPressReleaseParam param,
+  ) =>
+      repo.detail(
+        id: param.id,
+        lang: param.lang,
+        domain: param.domain,
+      );
+
+  @override
+  PressReleaseRepository get repo => getIt<PressReleaseRepository>();
+}
+
+class GetDetailPressReleaseParam extends Equatable {
+  const GetDetailPressReleaseParam({
+    required this.id,
+    required this.domain,
+    this.lang = DataLanguage.id,
+  });
+
+  final int id;
+  final String domain;
+  final DataLanguage lang;
+
+  @override
+  List<Object> get props => [id, domain, lang];
+}

--- a/lib/src/features/press_releases/press_releases.dart
+++ b/lib/src/features/press_releases/press_releases.dart
@@ -1,0 +1,1 @@
+export './domain/entities/press_release.dart';

--- a/lib/src/features/subject_categories/data/datasources/subject_category_remote_data_source.dart
+++ b/lib/src/features/subject_categories/data/datasources/subject_category_remote_data_source.dart
@@ -1,0 +1,58 @@
+// ignore_for_file: public_member_api_docs
+
+import 'package:injectable/injectable.dart';
+import 'package:stadata_flutter_sdk/src/core/di/service_locator.dart';
+import 'package:stadata_flutter_sdk/src/core/network/api_endpoint.dart';
+import 'package:stadata_flutter_sdk/src/core/network/http/modules/stadata_list_http_module.dart';
+import 'package:stadata_flutter_sdk/src/core/typedef/typedef.dart';
+import 'package:stadata_flutter_sdk/src/features/subject_categories/data/models/subject_category_model.dart';
+import 'package:stadata_flutter_sdk/src/shared/data/models/api_response_model.dart';
+import 'package:stadata_flutter_sdk/stadata_flutter_sdk.dart';
+
+abstract class SubjectCategoryRemoteDataSource {
+  Future<ApiResponseModel<List<SubjectCategoryModel>?>> get({
+    required String domain,
+    DataLanguage lang = DataLanguage.id,
+    int page = 1,
+  });
+}
+
+@LazySingleton(as: SubjectCategoryRemoteDataSource)
+class SubjectCategoryRemoteDataSourceImpl
+    implements SubjectCategoryRemoteDataSource {
+  final _listHttpModule = getIt<StadataListHttpModule>();
+
+  @override
+  Future<ApiResponseModel<List<SubjectCategoryModel>?>> get({
+    required String domain,
+    DataLanguage lang = DataLanguage.id,
+    int page = 1,
+  }) async {
+    final result = await _listHttpModule.get(
+      ApiEndpoint.subjectCategories(
+        domain: domain,
+        lang: lang,
+        page: page,
+      ),
+    );
+
+    final response = ApiResponseModel<List<SubjectCategoryModel>?>.fromJson(
+      result,
+      (json) {
+        if (json == null || json is! List) {
+          return null;
+        }
+
+        return json
+            .map((e) => SubjectCategoryModel.fromJson(e as JSON))
+            .toList();
+      },
+    );
+
+    if (response.dataAvailability == DataAvailability.listNotAvailable) {
+      throw const SubjectCategoryNotAvailableException();
+    }
+
+    return response;
+  }
+}

--- a/lib/src/features/subject_categories/data/models/subject_category_model.dart
+++ b/lib/src/features/subject_categories/data/models/subject_category_model.dart
@@ -1,0 +1,24 @@
+// ignore_for_file: public_member_api_docs
+
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:stadata_flutter_sdk/stadata_flutter_sdk.dart';
+
+part 'subject_category_model.freezed.dart';
+part 'subject_category_model.g.dart';
+
+@freezed
+abstract class SubjectCategoryModel with _$SubjectCategoryModel {
+  factory SubjectCategoryModel({
+    @JsonKey(name: 'subcat_id') required int id,
+    @JsonKey(name: 'title') required String name,
+  }) = _SubjectCategoryModel;
+  factory SubjectCategoryModel.fromJson(Map<String, dynamic> json) =>
+      _$SubjectCategoryModelFromJson(json);
+}
+
+extension SubjectCategoryModelX on SubjectCategoryModel {
+  SubjectCategory toEntity() => SubjectCategory(
+        id: id,
+        name: name,
+      );
+}

--- a/lib/src/features/subject_categories/data/models/subject_category_model.freezed.dart
+++ b/lib/src/features/subject_categories/data/models/subject_category_model.freezed.dart
@@ -1,0 +1,184 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'subject_category_model.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#custom-getters-and-methods');
+
+SubjectCategoryModel _$SubjectCategoryModelFromJson(Map<String, dynamic> json) {
+  return _SubjectCategoryModel.fromJson(json);
+}
+
+/// @nodoc
+mixin _$SubjectCategoryModel {
+  @JsonKey(name: 'subcat_id')
+  int get id => throw _privateConstructorUsedError;
+  @JsonKey(name: 'title')
+  String get name => throw _privateConstructorUsedError;
+
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+  @JsonKey(ignore: true)
+  $SubjectCategoryModelCopyWith<SubjectCategoryModel> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $SubjectCategoryModelCopyWith<$Res> {
+  factory $SubjectCategoryModelCopyWith(SubjectCategoryModel value,
+          $Res Function(SubjectCategoryModel) then) =
+      _$SubjectCategoryModelCopyWithImpl<$Res, SubjectCategoryModel>;
+  @useResult
+  $Res call(
+      {@JsonKey(name: 'subcat_id') int id,
+      @JsonKey(name: 'title') String name});
+}
+
+/// @nodoc
+class _$SubjectCategoryModelCopyWithImpl<$Res,
+        $Val extends SubjectCategoryModel>
+    implements $SubjectCategoryModelCopyWith<$Res> {
+  _$SubjectCategoryModelCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? id = null,
+    Object? name = null,
+  }) {
+    return _then(_value.copyWith(
+      id: null == id
+          ? _value.id
+          : id // ignore: cast_nullable_to_non_nullable
+              as int,
+      name: null == name
+          ? _value.name
+          : name // ignore: cast_nullable_to_non_nullable
+              as String,
+    ) as $Val);
+  }
+}
+
+/// @nodoc
+abstract class _$$_SubjectCategoryModelCopyWith<$Res>
+    implements $SubjectCategoryModelCopyWith<$Res> {
+  factory _$$_SubjectCategoryModelCopyWith(_$_SubjectCategoryModel value,
+          $Res Function(_$_SubjectCategoryModel) then) =
+      __$$_SubjectCategoryModelCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call(
+      {@JsonKey(name: 'subcat_id') int id,
+      @JsonKey(name: 'title') String name});
+}
+
+/// @nodoc
+class __$$_SubjectCategoryModelCopyWithImpl<$Res>
+    extends _$SubjectCategoryModelCopyWithImpl<$Res, _$_SubjectCategoryModel>
+    implements _$$_SubjectCategoryModelCopyWith<$Res> {
+  __$$_SubjectCategoryModelCopyWithImpl(_$_SubjectCategoryModel _value,
+      $Res Function(_$_SubjectCategoryModel) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? id = null,
+    Object? name = null,
+  }) {
+    return _then(_$_SubjectCategoryModel(
+      id: null == id
+          ? _value.id
+          : id // ignore: cast_nullable_to_non_nullable
+              as int,
+      name: null == name
+          ? _value.name
+          : name // ignore: cast_nullable_to_non_nullable
+              as String,
+    ));
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$_SubjectCategoryModel implements _SubjectCategoryModel {
+  _$_SubjectCategoryModel(
+      {@JsonKey(name: 'subcat_id') required this.id,
+      @JsonKey(name: 'title') required this.name});
+
+  factory _$_SubjectCategoryModel.fromJson(Map<String, dynamic> json) =>
+      _$$_SubjectCategoryModelFromJson(json);
+
+  @override
+  @JsonKey(name: 'subcat_id')
+  final int id;
+  @override
+  @JsonKey(name: 'title')
+  final String name;
+
+  @override
+  String toString() {
+    return 'SubjectCategoryModel(id: $id, name: $name)';
+  }
+
+  @override
+  bool operator ==(dynamic other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$_SubjectCategoryModel &&
+            (identical(other.id, id) || other.id == id) &&
+            (identical(other.name, name) || other.name == name));
+  }
+
+  @JsonKey(ignore: true)
+  @override
+  int get hashCode => Object.hash(runtimeType, id, name);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$_SubjectCategoryModelCopyWith<_$_SubjectCategoryModel> get copyWith =>
+      __$$_SubjectCategoryModelCopyWithImpl<_$_SubjectCategoryModel>(
+          this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$_SubjectCategoryModelToJson(
+      this,
+    );
+  }
+}
+
+abstract class _SubjectCategoryModel implements SubjectCategoryModel {
+  factory _SubjectCategoryModel(
+          {@JsonKey(name: 'subcat_id') required final int id,
+          @JsonKey(name: 'title') required final String name}) =
+      _$_SubjectCategoryModel;
+
+  factory _SubjectCategoryModel.fromJson(Map<String, dynamic> json) =
+      _$_SubjectCategoryModel.fromJson;
+
+  @override
+  @JsonKey(name: 'subcat_id')
+  int get id;
+  @override
+  @JsonKey(name: 'title')
+  String get name;
+  @override
+  @JsonKey(ignore: true)
+  _$$_SubjectCategoryModelCopyWith<_$_SubjectCategoryModel> get copyWith =>
+      throw _privateConstructorUsedError;
+}

--- a/lib/src/features/subject_categories/data/models/subject_category_model.g.dart
+++ b/lib/src/features/subject_categories/data/models/subject_category_model.g.dart
@@ -1,0 +1,21 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'subject_category_model.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_$_SubjectCategoryModel _$$_SubjectCategoryModelFromJson(
+        Map<String, dynamic> json) =>
+    _$_SubjectCategoryModel(
+      id: json['subcat_id'] as int,
+      name: json['title'] as String,
+    );
+
+Map<String, dynamic> _$$_SubjectCategoryModelToJson(
+        _$_SubjectCategoryModel instance) =>
+    <String, dynamic>{
+      'subcat_id': instance.id,
+      'title': instance.name,
+    };

--- a/lib/src/features/subject_categories/data/repositories/subject_category_repository_impl.dart
+++ b/lib/src/features/subject_categories/data/repositories/subject_category_repository_impl.dart
@@ -1,0 +1,58 @@
+// ignore_for_file: public_member_api_docs
+
+import 'dart:developer';
+
+import 'package:dartz/dartz.dart';
+import 'package:injectable/injectable.dart';
+import 'package:stadata_flutter_sdk/src/core/di/service_locator.dart';
+import 'package:stadata_flutter_sdk/src/core/failures/failures.dart';
+import 'package:stadata_flutter_sdk/src/features/subject_categories/data/datasources/subject_category_remote_data_source.dart';
+import 'package:stadata_flutter_sdk/src/features/subject_categories/data/models/subject_category_model.dart';
+import 'package:stadata_flutter_sdk/src/features/subject_categories/domain/repositories/subject_category_repository.dart';
+import 'package:stadata_flutter_sdk/src/shared/data/models/pagination_model.dart';
+import 'package:stadata_flutter_sdk/src/shared/domain/entities/api_response.dart';
+
+import 'package:stadata_flutter_sdk/stadata_flutter_sdk.dart';
+
+@LazySingleton(as: SubjectCategoryRepository)
+class SubjectCategoryRepositoryImpl implements SubjectCategoryRepository {
+  final _remoteDataSource = getIt<SubjectCategoryRemoteDataSource>();
+
+  @override
+  Future<Either<Failure, ApiResponse<List<SubjectCategory>>>> get({
+    required String domain,
+    DataLanguage lang = DataLanguage.id,
+    int page = 1,
+  }) async {
+    try {
+      final result = await _remoteDataSource.get(
+        domain: domain,
+        lang: lang,
+        page: page,
+      );
+
+      if (result.data == null) {
+        throw const SubjectCategoryNotAvailableException();
+      }
+
+      final data = result.data?.map((e) => e.toEntity()).toList() ?? [];
+
+      return Right(
+        ApiResponse<List<SubjectCategory>>(
+          data: data,
+          status: result.status,
+          message: result.message,
+          pagination: result.pagination?.toEntity(),
+          dataAvailability: result.dataAvailability,
+        ),
+      );
+    } catch (e) {
+      log(e.toString(), name: 'StadataException');
+      return Left(
+        SubjectCategoryFailure(
+          message: e.toString(),
+        ),
+      );
+    }
+  }
+}

--- a/lib/src/features/subject_categories/domain/entities/subject_category.dart
+++ b/lib/src/features/subject_categories/domain/entities/subject_category.dart
@@ -1,0 +1,24 @@
+import 'package:equatable/equatable.dart';
+
+/// Represents a Subject Category, including its unique identifier and name.
+///
+/// docs: https://webapi.bps.go.id/documentation/#subjectcategories
+
+class SubjectCategory extends Equatable {
+  /// Constructs a new instance of [SubjectCategory]
+  ///
+  /// - [id]: The unique identifier for the news category.
+  /// - [name]: The name of the subject category.
+  const SubjectCategory({
+    required this.id,
+    required this.name,
+  });
+
+  /// id of the subject category
+  final int id;
+
+  /// name of the subject category
+  final String name;
+  @override
+  List<Object> get props => [id, name];
+}

--- a/lib/src/features/subject_categories/domain/repositories/subject_category_repository.dart
+++ b/lib/src/features/subject_categories/domain/repositories/subject_category_repository.dart
@@ -1,0 +1,14 @@
+// ignore_for_file: one_member_abstracts, public_member_api_docs
+
+import 'package:dartz/dartz.dart';
+import 'package:stadata_flutter_sdk/src/core/failures/failures.dart';
+import 'package:stadata_flutter_sdk/src/shared/domain/entities/api_response.dart';
+import 'package:stadata_flutter_sdk/stadata_flutter_sdk.dart';
+
+abstract class SubjectCategoryRepository {
+  Future<Either<Failure, ApiResponse<List<SubjectCategory>>>> get({
+    required String domain,
+    DataLanguage lang = DataLanguage.id,
+    int page = 1,
+  });
+}

--- a/lib/src/features/subject_categories/domain/usecases/get_all_subject_categories.dart
+++ b/lib/src/features/subject_categories/domain/usecases/get_all_subject_categories.dart
@@ -1,0 +1,44 @@
+// ignore_for_file: public_member_api_docs
+
+import 'package:dartz/dartz.dart';
+import 'package:equatable/equatable.dart';
+import 'package:injectable/injectable.dart';
+import 'package:stadata_flutter_sdk/src/base/usecase.dart';
+import 'package:stadata_flutter_sdk/src/core/di/service_locator.dart';
+import 'package:stadata_flutter_sdk/src/core/failures/failures.dart';
+import 'package:stadata_flutter_sdk/src/features/subject_categories/domain/repositories/subject_category_repository.dart';
+import 'package:stadata_flutter_sdk/src/shared/domain/entities/api_response.dart';
+
+import 'package:stadata_flutter_sdk/stadata_flutter_sdk.dart';
+
+@LazySingleton()
+class GetAllSubjectCategories
+    implements
+        UseCase<ApiResponse<List<SubjectCategory>>,
+            GetAllSubjectCategoriesParam, SubjectCategoryRepository> {
+  @override
+  Future<Either<Failure, ApiResponse<List<SubjectCategory>>>> call(
+    GetAllSubjectCategoriesParam param,
+  ) =>
+      repo.get(
+        domain: param.domain,
+        lang: param.lang,
+        page: param.page,
+      );
+
+  @override
+  SubjectCategoryRepository get repo => getIt<SubjectCategoryRepository>();
+}
+
+class GetAllSubjectCategoriesParam extends Equatable {
+  const GetAllSubjectCategoriesParam({
+    required this.domain,
+    this.lang = DataLanguage.id,
+    this.page = 1,
+  });
+  final String domain;
+  final DataLanguage lang;
+  final int page;
+  @override
+  List<Object> get props => [domain, lang, page];
+}

--- a/lib/src/features/subject_categories/subject_categories.dart
+++ b/lib/src/features/subject_categories/subject_categories.dart
@@ -1,0 +1,1 @@
+export './domain/entities/subject_category.dart';

--- a/lib/src/features/subjects/data/datasources/subject_remote_data_source.dart
+++ b/lib/src/features/subjects/data/datasources/subject_remote_data_source.dart
@@ -1,0 +1,58 @@
+// ignore_for_file: public_member_api_docs
+
+import 'package:injectable/injectable.dart';
+import 'package:stadata_flutter_sdk/src/core/di/service_locator.dart';
+import 'package:stadata_flutter_sdk/src/core/network/api_endpoint.dart';
+import 'package:stadata_flutter_sdk/src/core/network/http/modules/stadata_list_http_module.dart';
+import 'package:stadata_flutter_sdk/src/core/typedef/typedef.dart';
+import 'package:stadata_flutter_sdk/src/features/subjects/data/models/subject_model.dart';
+import 'package:stadata_flutter_sdk/src/shared/data/models/api_response_model.dart';
+import 'package:stadata_flutter_sdk/stadata_flutter_sdk.dart';
+
+abstract class SubjectRemoteDataSource {
+  Future<ApiResponseModel<List<SubjectModel>?>> get({
+    required String domain,
+    int? subjectCategoryId,
+    DataLanguage lang = DataLanguage.id,
+    int page = 1,
+  });
+}
+
+@LazySingleton(as: SubjectRemoteDataSource)
+class SubjectModelRemoteDataSourceImpl implements SubjectRemoteDataSource {
+  final _listHttpModule = getIt<StadataListHttpModule>();
+
+  @override
+  Future<ApiResponseModel<List<SubjectModel>?>> get({
+    required String domain,
+    int? subjectCategoryId,
+    DataLanguage lang = DataLanguage.id,
+    int page = 1,
+  }) async {
+    final result = await _listHttpModule.get(
+      ApiEndpoint.subjects(
+        lang: lang,
+        page: page,
+        domain: domain,
+        subjectCategoryId: subjectCategoryId,
+      ),
+    );
+
+    final response = ApiResponseModel<List<SubjectModel>?>.fromJson(
+      result,
+      (json) {
+        if (json == null || json is! List) {
+          return null;
+        }
+
+        return json.map((e) => SubjectModel.fromJson(e as JSON)).toList();
+      },
+    );
+
+    if (response.dataAvailability == DataAvailability.listNotAvailable) {
+      throw const SubjectNotAvailableException();
+    }
+
+    return response;
+  }
+}

--- a/lib/src/features/subjects/data/models/subject_model.dart
+++ b/lib/src/features/subjects/data/models/subject_model.dart
@@ -1,0 +1,41 @@
+// ignore_for_file: public_member_api_docs, invalid_annotation_target
+
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:stadata_flutter_sdk/src/features/subject_categories/data/models/subject_category_model.dart';
+import 'package:stadata_flutter_sdk/stadata_flutter_sdk.dart';
+
+part 'subject_model.freezed.dart';
+part 'subject_model.g.dart';
+
+@freezed
+abstract class SubjectModel with _$SubjectModel {
+  factory SubjectModel({
+    @JsonKey(name: 'sub_id') required int id,
+    @JsonKey(name: 'title') required String name,
+    @JsonKey(name: 'subcat_id', readValue: _categoryValueReader)
+    SubjectCategoryModel? category,
+    @JsonKey(name: 'ntabel') int? nTable,
+  }) = _SubjectModel;
+  factory SubjectModel.fromJson(Map<String, dynamic> json) =>
+      _$SubjectModelFromJson(json);
+}
+
+Object? _categoryValueReader(Map<dynamic, dynamic> json, String key) {
+  if (json['subcat_id'] == null || json['subcat'] == null) {
+    return null;
+  }
+
+  return SubjectCategoryModel(
+    id: json['subcat_id'] as int,
+    name: json['subcat'] as String,
+  ).toJson();
+}
+
+extension SubjectModelX on SubjectModel {
+  Subject toEntity() => Subject(
+        id: id,
+        name: name,
+        nTable: nTable,
+        category: category?.toEntity(),
+      );
+}

--- a/lib/src/features/subjects/data/models/subject_model.freezed.dart
+++ b/lib/src/features/subjects/data/models/subject_model.freezed.dart
@@ -1,0 +1,249 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'subject_model.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#custom-getters-and-methods');
+
+SubjectModel _$SubjectModelFromJson(Map<String, dynamic> json) {
+  return _SubjectModel.fromJson(json);
+}
+
+/// @nodoc
+mixin _$SubjectModel {
+  @JsonKey(name: 'sub_id')
+  int get id => throw _privateConstructorUsedError;
+  @JsonKey(name: 'title')
+  String get name => throw _privateConstructorUsedError;
+  @JsonKey(name: 'subcat_id', readValue: _categoryValueReader)
+  SubjectCategoryModel? get category => throw _privateConstructorUsedError;
+  @JsonKey(name: 'ntabel')
+  int? get nTable => throw _privateConstructorUsedError;
+
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+  @JsonKey(ignore: true)
+  $SubjectModelCopyWith<SubjectModel> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $SubjectModelCopyWith<$Res> {
+  factory $SubjectModelCopyWith(
+          SubjectModel value, $Res Function(SubjectModel) then) =
+      _$SubjectModelCopyWithImpl<$Res, SubjectModel>;
+  @useResult
+  $Res call(
+      {@JsonKey(name: 'sub_id') int id,
+      @JsonKey(name: 'title') String name,
+      @JsonKey(name: 'subcat_id', readValue: _categoryValueReader)
+      SubjectCategoryModel? category,
+      @JsonKey(name: 'ntabel') int? nTable});
+
+  $SubjectCategoryModelCopyWith<$Res>? get category;
+}
+
+/// @nodoc
+class _$SubjectModelCopyWithImpl<$Res, $Val extends SubjectModel>
+    implements $SubjectModelCopyWith<$Res> {
+  _$SubjectModelCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? id = null,
+    Object? name = null,
+    Object? category = freezed,
+    Object? nTable = freezed,
+  }) {
+    return _then(_value.copyWith(
+      id: null == id
+          ? _value.id
+          : id // ignore: cast_nullable_to_non_nullable
+              as int,
+      name: null == name
+          ? _value.name
+          : name // ignore: cast_nullable_to_non_nullable
+              as String,
+      category: freezed == category
+          ? _value.category
+          : category // ignore: cast_nullable_to_non_nullable
+              as SubjectCategoryModel?,
+      nTable: freezed == nTable
+          ? _value.nTable
+          : nTable // ignore: cast_nullable_to_non_nullable
+              as int?,
+    ) as $Val);
+  }
+
+  @override
+  @pragma('vm:prefer-inline')
+  $SubjectCategoryModelCopyWith<$Res>? get category {
+    if (_value.category == null) {
+      return null;
+    }
+
+    return $SubjectCategoryModelCopyWith<$Res>(_value.category!, (value) {
+      return _then(_value.copyWith(category: value) as $Val);
+    });
+  }
+}
+
+/// @nodoc
+abstract class _$$_SubjectModelCopyWith<$Res>
+    implements $SubjectModelCopyWith<$Res> {
+  factory _$$_SubjectModelCopyWith(
+          _$_SubjectModel value, $Res Function(_$_SubjectModel) then) =
+      __$$_SubjectModelCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call(
+      {@JsonKey(name: 'sub_id') int id,
+      @JsonKey(name: 'title') String name,
+      @JsonKey(name: 'subcat_id', readValue: _categoryValueReader)
+      SubjectCategoryModel? category,
+      @JsonKey(name: 'ntabel') int? nTable});
+
+  @override
+  $SubjectCategoryModelCopyWith<$Res>? get category;
+}
+
+/// @nodoc
+class __$$_SubjectModelCopyWithImpl<$Res>
+    extends _$SubjectModelCopyWithImpl<$Res, _$_SubjectModel>
+    implements _$$_SubjectModelCopyWith<$Res> {
+  __$$_SubjectModelCopyWithImpl(
+      _$_SubjectModel _value, $Res Function(_$_SubjectModel) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? id = null,
+    Object? name = null,
+    Object? category = freezed,
+    Object? nTable = freezed,
+  }) {
+    return _then(_$_SubjectModel(
+      id: null == id
+          ? _value.id
+          : id // ignore: cast_nullable_to_non_nullable
+              as int,
+      name: null == name
+          ? _value.name
+          : name // ignore: cast_nullable_to_non_nullable
+              as String,
+      category: freezed == category
+          ? _value.category
+          : category // ignore: cast_nullable_to_non_nullable
+              as SubjectCategoryModel?,
+      nTable: freezed == nTable
+          ? _value.nTable
+          : nTable // ignore: cast_nullable_to_non_nullable
+              as int?,
+    ));
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$_SubjectModel implements _SubjectModel {
+  _$_SubjectModel(
+      {@JsonKey(name: 'sub_id') required this.id,
+      @JsonKey(name: 'title') required this.name,
+      @JsonKey(name: 'subcat_id', readValue: _categoryValueReader)
+      this.category,
+      @JsonKey(name: 'ntabel') this.nTable});
+
+  factory _$_SubjectModel.fromJson(Map<String, dynamic> json) =>
+      _$$_SubjectModelFromJson(json);
+
+  @override
+  @JsonKey(name: 'sub_id')
+  final int id;
+  @override
+  @JsonKey(name: 'title')
+  final String name;
+  @override
+  @JsonKey(name: 'subcat_id', readValue: _categoryValueReader)
+  final SubjectCategoryModel? category;
+  @override
+  @JsonKey(name: 'ntabel')
+  final int? nTable;
+
+  @override
+  String toString() {
+    return 'SubjectModel(id: $id, name: $name, category: $category, nTable: $nTable)';
+  }
+
+  @override
+  bool operator ==(dynamic other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$_SubjectModel &&
+            (identical(other.id, id) || other.id == id) &&
+            (identical(other.name, name) || other.name == name) &&
+            (identical(other.category, category) ||
+                other.category == category) &&
+            (identical(other.nTable, nTable) || other.nTable == nTable));
+  }
+
+  @JsonKey(ignore: true)
+  @override
+  int get hashCode => Object.hash(runtimeType, id, name, category, nTable);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$_SubjectModelCopyWith<_$_SubjectModel> get copyWith =>
+      __$$_SubjectModelCopyWithImpl<_$_SubjectModel>(this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$_SubjectModelToJson(
+      this,
+    );
+  }
+}
+
+abstract class _SubjectModel implements SubjectModel {
+  factory _SubjectModel(
+      {@JsonKey(name: 'sub_id') required final int id,
+      @JsonKey(name: 'title') required final String name,
+      @JsonKey(name: 'subcat_id', readValue: _categoryValueReader)
+      final SubjectCategoryModel? category,
+      @JsonKey(name: 'ntabel') final int? nTable}) = _$_SubjectModel;
+
+  factory _SubjectModel.fromJson(Map<String, dynamic> json) =
+      _$_SubjectModel.fromJson;
+
+  @override
+  @JsonKey(name: 'sub_id')
+  int get id;
+  @override
+  @JsonKey(name: 'title')
+  String get name;
+  @override
+  @JsonKey(name: 'subcat_id', readValue: _categoryValueReader)
+  SubjectCategoryModel? get category;
+  @override
+  @JsonKey(name: 'ntabel')
+  int? get nTable;
+  @override
+  @JsonKey(ignore: true)
+  _$$_SubjectModelCopyWith<_$_SubjectModel> get copyWith =>
+      throw _privateConstructorUsedError;
+}

--- a/lib/src/features/subjects/data/models/subject_model.g.dart
+++ b/lib/src/features/subjects/data/models/subject_model.g.dart
@@ -1,0 +1,26 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'subject_model.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_$_SubjectModel _$$_SubjectModelFromJson(Map<String, dynamic> json) =>
+    _$_SubjectModel(
+      id: json['sub_id'] as int,
+      name: json['title'] as String,
+      category: _categoryValueReader(json, 'subcat_id') == null
+          ? null
+          : SubjectCategoryModel.fromJson(
+              _categoryValueReader(json, 'subcat_id') as Map<String, dynamic>),
+      nTable: json['ntabel'] as int?,
+    );
+
+Map<String, dynamic> _$$_SubjectModelToJson(_$_SubjectModel instance) =>
+    <String, dynamic>{
+      'sub_id': instance.id,
+      'title': instance.name,
+      'subcat_id': instance.category,
+      'ntabel': instance.nTable,
+    };

--- a/lib/src/features/subjects/data/repositories/subject_repository_impl.dart
+++ b/lib/src/features/subjects/data/repositories/subject_repository_impl.dart
@@ -1,0 +1,60 @@
+// ignore_for_file: public_member_api_docs, unnecessary_import
+
+import 'dart:developer';
+
+import 'package:dartz/dartz.dart';
+import 'package:injectable/injectable.dart';
+import 'package:stadata_flutter_sdk/src/core/di/service_locator.dart';
+import 'package:stadata_flutter_sdk/src/core/failures/failures.dart';
+import 'package:stadata_flutter_sdk/src/features/subjects/data/datasources/subject_remote_data_source.dart';
+import 'package:stadata_flutter_sdk/src/features/subjects/data/models/subject_model.dart';
+import 'package:stadata_flutter_sdk/src/features/subjects/domain/entities/subject.dart';
+import 'package:stadata_flutter_sdk/src/features/subjects/domain/repositories/subject_repository.dart';
+import 'package:stadata_flutter_sdk/src/shared/data/models/pagination_model.dart';
+import 'package:stadata_flutter_sdk/src/shared/domain/entities/api_response.dart';
+import 'package:stadata_flutter_sdk/src/shared/domain/enums/data_language.dart';
+import 'package:stadata_flutter_sdk/stadata_flutter_sdk.dart';
+
+@LazySingleton(as: SubjectRepository)
+class SubjectRepositoryImpl implements SubjectRepository {
+  final _remoteDataSource = getIt<SubjectRemoteDataSource>();
+  @override
+  Future<Either<Failure, ApiResponse<List<Subject>>>> get({
+    required String domain,
+    int? subjectCategoryId,
+    DataLanguage lang = DataLanguage.id,
+    int page = 1,
+  }) async {
+    try {
+      final result = await _remoteDataSource.get(
+        lang: lang,
+        page: page,
+        domain: domain,
+        subjectCategoryId: subjectCategoryId,
+      );
+
+      if (result.data == null) {
+        throw const SubjectNotAvailableException();
+      }
+
+      final data = result.data?.map((e) => e.toEntity()).toList();
+
+      return Right(
+        ApiResponse<List<Subject>>(
+          data: data,
+          status: result.status,
+          message: result.message,
+          pagination: result.pagination?.toEntity(),
+          dataAvailability: result.dataAvailability,
+        ),
+      );
+    } catch (e) {
+      log(e.toString(), name: 'StadataException');
+      return Left(
+        SubjectFailure(
+          message: e.toString(),
+        ),
+      );
+    }
+  }
+}

--- a/lib/src/features/subjects/domain/entities/subject.dart
+++ b/lib/src/features/subjects/domain/entities/subject.dart
@@ -1,0 +1,35 @@
+import 'package:equatable/equatable.dart';
+import 'package:stadata_flutter_sdk/stadata_flutter_sdk.dart';
+
+/// Represents a Subject, including its id, name, category, and nTable
+///
+/// [docs]: https://webapi.bps.go.id/documentation/#subject
+class Subject extends Equatable {
+  /// Constructs a new instance of [Subject]
+  ///
+  /// - [id]: The unique identifier for the Subject.
+  /// - [name]: The name of the subject.
+  /// - [category]: Category of the subject.
+  /// - [nTable]: Sum of table on each subject
+  const Subject({
+    required this.id,
+    required this.name,
+    this.category,
+    this.nTable,
+  });
+
+  /// Represents the unique identifier of the Subject.
+  final int id;
+
+  /// Represents the name of the Subject.
+  final String name;
+
+  /// Represent the category of the Subject.
+  final SubjectCategory? category;
+
+  /// Sum of the table on this subject.
+  final int? nTable;
+
+  @override
+  List<Object?> get props => [id, name, category, nTable];
+}

--- a/lib/src/features/subjects/domain/repositories/subject_repository.dart
+++ b/lib/src/features/subjects/domain/repositories/subject_repository.dart
@@ -1,0 +1,15 @@
+// ignore_for_file: public_member_api_docs
+
+import 'package:dartz/dartz.dart';
+import 'package:stadata_flutter_sdk/src/core/failures/failures.dart';
+import 'package:stadata_flutter_sdk/src/shared/domain/entities/api_response.dart';
+import 'package:stadata_flutter_sdk/stadata_flutter_sdk.dart';
+
+abstract class SubjectRepository {
+  Future<Either<Failure, ApiResponse<List<Subject>>>> get({
+    required String domain,
+     int? subjectCategoryId,
+    DataLanguage lang = DataLanguage.id,
+    int page = 1,
+  });
+}

--- a/lib/src/features/subjects/domain/repositories/subject_repository.dart
+++ b/lib/src/features/subjects/domain/repositories/subject_repository.dart
@@ -8,7 +8,7 @@ import 'package:stadata_flutter_sdk/stadata_flutter_sdk.dart';
 abstract class SubjectRepository {
   Future<Either<Failure, ApiResponse<List<Subject>>>> get({
     required String domain,
-     int? subjectCategoryId,
+    int? subjectCategoryId,
     DataLanguage lang = DataLanguage.id,
     int page = 1,
   });

--- a/lib/src/features/subjects/domain/usecases/get_all_subjects.dart
+++ b/lib/src/features/subjects/domain/usecases/get_all_subjects.dart
@@ -1,0 +1,47 @@
+// ignore_for_file: public_member_api_docs
+
+import 'package:dartz/dartz.dart';
+import 'package:equatable/equatable.dart';
+import 'package:injectable/injectable.dart';
+import 'package:stadata_flutter_sdk/src/base/usecase.dart';
+import 'package:stadata_flutter_sdk/src/core/di/service_locator.dart';
+import 'package:stadata_flutter_sdk/src/core/failures/failures.dart';
+import 'package:stadata_flutter_sdk/src/features/subjects/domain/repositories/subject_repository.dart';
+import 'package:stadata_flutter_sdk/src/shared/domain/entities/api_response.dart';
+
+import 'package:stadata_flutter_sdk/stadata_flutter_sdk.dart';
+
+@LazySingleton()
+class GetAllSubjects
+    implements
+        UseCase<ApiResponse<List<Subject>>, GetAllSubjectsParam,
+            SubjectRepository> {
+  @override
+  Future<Either<Failure, ApiResponse<List<Subject>>>> call(
+    GetAllSubjectsParam param,
+  ) =>
+      repo.get(
+        page: param.page,
+        lang: param.lang,
+        domain: param.domain,
+        subjectCategoryId: param.subjectCategoryId,
+      );
+
+  @override
+  SubjectRepository get repo => getIt<SubjectRepository>();
+}
+
+class GetAllSubjectsParam extends Equatable {
+  const GetAllSubjectsParam({
+    required this.domain,
+    this.subjectCategoryId,
+    this.lang = DataLanguage.id,
+    this.page = 1,
+  });
+  final String domain;
+  final DataLanguage lang;
+  final int page;
+  final int? subjectCategoryId;
+  @override
+  List<Object?> get props => [domain, lang, page, subjectCategoryId];
+}

--- a/lib/src/features/subjects/subjects.dart
+++ b/lib/src/features/subjects/subjects.dart
@@ -1,0 +1,1 @@
+export './domain/entities/subject.dart';

--- a/lib/src/list/list.dart
+++ b/lib/src/list/list.dart
@@ -6,8 +6,11 @@ import 'package:stadata_flutter_sdk/src/features/domains/domain/usecases/get_dom
 import 'package:stadata_flutter_sdk/src/features/infographics/domain/usecases/get_all_infographics.dart';
 import 'package:stadata_flutter_sdk/src/features/news/domain/usecases/get_all_news.dart';
 import 'package:stadata_flutter_sdk/src/features/news_categories/domain/usecases/get_all_news_categories.dart';
+import 'package:stadata_flutter_sdk/src/features/press_releases/domain/usecases/get_all_press_releases.dart';
 import 'package:stadata_flutter_sdk/src/features/publications/domain/usecases/get_all_publication.dart';
 import 'package:stadata_flutter_sdk/src/features/static_tables/domain/usecases/get_all_static_tables.dart';
+import 'package:stadata_flutter_sdk/src/features/subject_categories/domain/usecases/get_all_subject_categories.dart';
+import 'package:stadata_flutter_sdk/src/features/subjects/domain/usecases/get_all_subjects.dart';
 import 'package:stadata_flutter_sdk/stadata_flutter_sdk.dart';
 
 abstract class StadataList {
@@ -55,6 +58,28 @@ abstract class StadataList {
     required String domain,
     DataLanguage lang = DataLanguage.id,
   });
+
+  Future<ListResult<SubjectCategory>> subjectCategories({
+    required String domain,
+    DataLanguage lang = DataLanguage.id,
+    int page = 1,
+  });
+
+  Future<ListResult<Subject>> subjects({
+    required String domain,
+    required int subjectCategoryId,
+    DataLanguage lang = DataLanguage.id,
+    int page = 1,
+  });
+
+  Future<ListResult<PressRelease>> pressReleases({
+    required String domain,
+    DataLanguage lang = DataLanguage.id,
+    int page = 1,
+    String? keyword,
+    int? month,
+    int? year,
+  });
 }
 
 @LazySingleton(as: StadataList)
@@ -65,6 +90,9 @@ class StadataListImpl implements StadataList {
   final _getAllStaticTables = getIt<GetAllStaticTables>();
   final _getAllNews = getIt<GetAllNews>();
   final _getAllNewsCategories = getIt<GetAllNewsCategories>();
+  final _getAllSubjectCategories = getIt<GetAllSubjectCategories>();
+  final _getAllSubjects = getIt<GetAllSubjects>();
+  final _getAllPressReleases = getIt<GetAllPressReleases>();
 
   @override
   Future<ListResult<DomainEntity>> domains({
@@ -216,6 +244,84 @@ class StadataListImpl implements StadataList {
     return result.fold(
       (l) => throw NewsCategoryException(message: l.message),
       (r) => ListResult<NewsCategory>(
+        data: r.data ?? [],
+        pagination: r.pagination,
+      ),
+    );
+  }
+
+  @override
+  Future<ListResult<SubjectCategory>> subjectCategories({
+    required String domain,
+    DataLanguage lang = DataLanguage.id,
+    int page = 1,
+  }) async {
+    final result = await _getAllSubjectCategories(
+      GetAllSubjectCategoriesParam(
+        lang: lang,
+        page: page,
+        domain: domain,
+      ),
+    );
+
+    return result.fold(
+      (l) => throw SubjectCategoryException(
+        message: l.message,
+      ),
+      (r) => ListResult<SubjectCategory>(
+        data: r.data ?? [],
+        pagination: r.pagination,
+      ),
+    );
+  }
+
+  @override
+  Future<ListResult<Subject>> subjects({
+    required String domain,
+    required int subjectCategoryId,
+    DataLanguage lang = DataLanguage.id,
+    int page = 1,
+  }) async {
+    final result = await _getAllSubjects(
+      GetAllSubjectsParam(
+        page: page,
+        lang: lang,
+        domain: domain,
+        subjectCategoryId: subjectCategoryId,
+      ),
+    );
+
+    return result.fold(
+      (l) => throw SubjectException(message: l.message),
+      (r) => ListResult<Subject>(
+        data: r.data ?? [],
+        pagination: r.pagination,
+      ),
+    );
+  }
+
+  @override
+  Future<ListResult<PressRelease>> pressReleases({
+    required String domain,
+    DataLanguage lang = DataLanguage.id,
+    int page = 1,
+    String? keyword,
+    int? month,
+    int? year,
+  }) async {
+    final result = await _getAllPressReleases(
+      GetAllPressReleasesParam(
+        page: page,
+        year: year,
+        month: month,
+        domain: domain,
+        keyword: keyword,
+      ),
+    );
+
+    return result.fold(
+      (l) => throw PressReleaseException(message: l.message),
+      (r) => ListResult<PressRelease>(
         data: r.data ?? [],
         pagination: r.pagination,
       ),

--- a/lib/src/list/list.dart
+++ b/lib/src/list/list.dart
@@ -67,7 +67,7 @@ abstract class StadataList {
 
   Future<ListResult<Subject>> subjects({
     required String domain,
-    required int subjectCategoryId,
+    int subjectCategoryId,
     DataLanguage lang = DataLanguage.id,
     int page = 1,
   });
@@ -278,7 +278,7 @@ class StadataListImpl implements StadataList {
   @override
   Future<ListResult<Subject>> subjects({
     required String domain,
-    required int subjectCategoryId,
+    int? subjectCategoryId,
     DataLanguage lang = DataLanguage.id,
     int page = 1,
   }) async {

--- a/lib/src/view/view.dart
+++ b/lib/src/view/view.dart
@@ -1,6 +1,7 @@
 import 'package:injectable/injectable.dart';
 import 'package:stadata_flutter_sdk/src/core/di/service_locator.dart';
 import 'package:stadata_flutter_sdk/src/features/news/domain/usecases/get_detail_news.dart';
+import 'package:stadata_flutter_sdk/src/features/press_releases/domain/usecases/get_detail_press_release.dart';
 import 'package:stadata_flutter_sdk/src/features/publications/domain/usecases/get_detail_publication.dart';
 import 'package:stadata_flutter_sdk/src/features/static_tables/domain/usecases/get_detail_static_table.dart';
 import 'package:stadata_flutter_sdk/stadata_flutter_sdk.dart';
@@ -44,6 +45,18 @@ abstract class StadataView {
     required String domain,
     DataLanguage lang = DataLanguage.id,
   });
+
+  /// Fetches detailed information about a press release.
+  ///
+  /// - [id]: The unique identifier of the press release.
+  /// - [domain]: The domain to which the press release.
+  /// - [lang]: The data language  of request (default is [DataLanguage.id]).
+
+  Future<PressRelease?> pressRelease({
+    required int id,
+    required String domain,
+    DataLanguage lang = DataLanguage.id,
+  });
 }
 
 /// Implementation of the [StadataView] interface.
@@ -55,6 +68,7 @@ class StadataViewImpl implements StadataView {
   final _getDetailNews = getIt<GetDetailNews>();
   final _getDetailPublication = getIt<GetDetailPublication>();
   final _getDetailStaticTable = getIt<GetDetailStaticTable>();
+  final _getDetailPressRelease = getIt<GetDetailPressRelease>();
 
   @override
   Future<Publication?> publication({
@@ -112,6 +126,26 @@ class StadataViewImpl implements StadataView {
 
     return result.fold(
       (l) => throw NewsException(message: l.message),
+      (r) => r.data,
+    );
+  }
+
+  @override
+  Future<PressRelease?> pressRelease({
+    required int id,
+    required String domain,
+    DataLanguage lang = DataLanguage.id,
+  }) async {
+    final result = await _getDetailPressRelease(
+      GetDetailPressReleaseParam(
+        id: id,
+        lang: lang,
+        domain: domain,
+      ),
+    );
+
+    return result.fold(
+      (l) => throw PressReleaseException(message: l.message),
       (r) => r.data,
     );
   }

--- a/test/fixtures/fixtures.dart
+++ b/test/fixtures/fixtures.dart
@@ -14,6 +14,7 @@ enum Fixture {
   staticTables('static_table_list_fixture.json'),
   staticTableDetail('static_table_detail_fixture.json'),
   subjectCategories('subject_category_list_fixture.json'),
+  subjects('subject_list_fixture.json'),
   unavailable('unavailable_fixture.json');
 
   const Fixture(this.value);

--- a/test/fixtures/fixtures.dart
+++ b/test/fixtures/fixtures.dart
@@ -11,6 +11,8 @@ enum Fixture {
   newsDetail('news_detail_fixture.json'),
   publications('publication_list_fixture.json'),
   publicationDetail('publication_detail_fixture.json'),
+  pressReleases('press_release_list_fixture.json'),
+  pressReleaseDetail('press_release_detail_fixture.json'),
   staticTables('static_table_list_fixture.json'),
   staticTableDetail('static_table_detail_fixture.json'),
   subjectCategories('subject_category_list_fixture.json'),

--- a/test/fixtures/fixtures.dart
+++ b/test/fixtures/fixtures.dart
@@ -13,6 +13,7 @@ enum Fixture {
   publicationDetail('publication_detail_fixture.json'),
   staticTables('static_table_list_fixture.json'),
   staticTableDetail('static_table_detail_fixture.json'),
+  subjectCategories('subject_category_list_fixture.json'),
   unavailable('unavailable_fixture.json');
 
   const Fixture(this.value);

--- a/test/fixtures/press_release_detail_fixture.json
+++ b/test/fixtures/press_release_detail_fixture.json
@@ -1,0 +1,16 @@
+{
+    "status": "OK",
+    "data-availability": "available",
+    "data": {
+        "brs_id": 26,
+        "title": "NTP Naik Sebesar 0.11 Persen  dan Harga Gabah (GKP) Naik 3.54 Persen",
+        "abstract": "&quot;Nilai Tukar Petani (NTP) nasional Desember 2011 sebesar 105,75 atau naik 0,11 persen dibanding NTP\nbulan sebelumnya. Kenaikan NTP dikarenakan naiknya NTP Subsektor Tanaman Pangan sebesar 0,35\npersen dan NTP Subsektor Hortikultura sebesar 0,28 persen.\n&lt;br&gt;&lt;br&gt;\nSelama 2011 kenaikan NTP tertinggi pada April 2011 dan Mei 2011 yaitu masing-masing naik sebesar\n0,57 persen sedangkan NTP terendah terjadi pada Maret 2011 yang turun sebesar 0,01 persen. Selama\n2011 terjadi kenaikan NTP sebesar 2,92 persen.\n&lt;br&gt;&lt;br&gt;\nPada Desember 2011, NTP Provinsi Bengkulu mengalami kenaikan tertinggi (0,77 persen) dibandingkan\nkenaikan NTP provinsi lainnya. Sebaliknya, NTP Provinsi Maluku terjadi penurunan terbesar (0,54\npersen) dibanding penurunan NTP provinsi lainnya.\n&lt;br&gt;&lt;br&gt;\nPada Desember 2011, terjadi inflasi di daerah perdesaan di Indonesia sebesar 0,37 persen terutama\ndipicu oleh naiknya indeks Kelompok Bahan Makanan dan Kelompok Perumahan. Sedangkan inflasi\nperdesaan di Indonesia selama tahun 2011 sebesar 3,48 persen.\n&lt;br&gt;&lt;br&gt;\nBerdasarkan 930 transaksi penjualan gabah di 19 provinsi selama Desember 2011, didominasi\ntransaksi gabah kering panen (GKP) 78,60 persen, gabah kualitas rendah 10,97 persen, dan\ngabah kering giling (GKG) 10,43 persen.\n&lt;br&gt;&lt;br&gt;\nSelama Desember 2011, rata-rata harga gabah kualitas GKP di petani Rp4.085,15 per kg (naik\n3,54 persen) dan di penggilingan Rp4.150,90 per kg (naik 3,59 persen) dibandingkan kualitas\nyang sama November 2011. Sedangkan gabah kualitas GKG di petani Rp4.548,27 per kg (naik\n3,41 persen) dan di penggilingan Rp4.619,81 per kg (naik 3,50 persen).\n&lt;br&gt;&lt;br&gt;\nDibandingkan Desember 2010, keseluruhan kelompok kualitas gabah di petani meningkat\nmasing-masing kualitas GKP (12,96 persen), kualitas GKG (17,56 persen), dan kualitas rendah\n(14,33 persen) selama Desember 2011. Sedangkan di penggilingan, kualitas GKP (12,76\npersen), kualitas GKG (17,42 persen), dan kualitas rendah (13,10 persen).&quot;",
+        "rl_date": "2012-01-02",
+        "updt_date": null,
+        "pdf": "https://www.bps.go.id/pressrelease/downloadapi.html?data=385wwvDCbVsya8%2Bs%2BJSopcT1cuSXlsrwLnSL6d6HYzXuiLHluosssQ6%2BG92Js2VyvVmIvb%2FiTxNc3dpP5NfWSw%3D%3D&tokenuser=",
+        "size": "0.2 MB",
+        "hit": 4954,
+        "thumbnail": "https://www.bps.go.id/images/default.png",
+        "slide": ""
+    }
+}

--- a/test/fixtures/press_release_list_fixture.json
+++ b/test/fixtures/press_release_list_fixture.json
@@ -1,0 +1,41 @@
+{
+    "status": "OK",
+    "data-availability": "available",
+    "data": [
+        {
+            "page": 1,
+            "pages": 1,
+            "per_page": 10,
+            "count": 2,
+            "total": 2
+        },
+        [
+            {
+                "brs_id": 1969,
+                "subj_id": 8,
+                "subj": "Ekspor-Impor",
+                "title": "Ekspor Agustus 2023 mencapai US$22,00 miliar, naik 5,47 persen dibanding Juli 2023 dan Impor Agustus 2023 senilai US$18,88 miliar, turun 3,53 persen dibanding Juli 2023",
+                "abstract": "&lt;b&gt;A. PERKEMBANGAN EKSPOR&lt;/b&gt;&lt;div&gt;&lt;ul&gt;&lt;li&gt;&lt;span style=&quot;font-size: 10pt;&quot;&gt;Nilai ekspor Indonesia Agustus 2023 mencapai US$22,00 miliar atau naik 5,47\r\npersen dibanding ekspor Juli 2023. Dibanding Agustus 2022 nilai ekspor turun\r\nsebesar 21,21 persen.&lt;/span&gt;&lt;/li&gt;&lt;li&gt;&lt;span style=&quot;font-size: 10pt;&quot;&gt;Ekspor nonmigas Agustus 2023 mencapai US$20,69 miliar, naik 5,35 persen\r\ndibanding Juli 2023, dan turun 21,25 persen jika dibanding ekspor nonmigas\r\nAgustus 2022.&lt;/span&gt;&lt;/li&gt;&lt;li&gt;&lt;span style=&quot;font-size: 10pt;&quot;&gt;Secara kumulatif, nilai ekspor Indonesia Januari–Agustus 2023 mencapai\r\nUS$171,52 miliar atau turun 11,85 persen dibanding periode yang sama tahun\r\n2022. Sementara ekspor nonmigas mencapai US$161,13 miliar atau turun 12,27\r\npersen.&lt;/span&gt;&lt;/li&gt;&lt;li&gt;&lt;span style=&quot;font-size: 10pt;&quot;&gt;Peningkatan terbesar ekspor nonmigas Agustus 2023 terhadap Juli 2023 terjadi\r\npada komoditas bijih logam, terak, dan abu sebesar US$790,8 juta (223,50 persen),\r\nsedangkan penurunan terbesar terjadi pada bahan bakar mineral sebesar US$265,6\r\njuta (8,42 persen).&lt;/span&gt;&lt;/li&gt;&lt;li&gt;&lt;span style=&quot;font-size: 10pt;&quot;&gt;Menurut sektor, ekspor nonmigas hasil industri pengolahan Januari–Agustus\r\n2023 turun 11,08 persen dibanding periode yang sama tahun 2022, demikian juga\r\nekspor hasil pertanian, kehutanan, dan perikanan turun 8,14 persen dan ekspor\r\nhasil pertambangan dan lainnya turun 16,58 persen.&lt;/span&gt;&lt;/li&gt;&lt;li&gt;&lt;span style=&quot;font-size: 10pt;&quot;&gt;Ekspor nonmigas Agustus 2023 terbesar adalah ke Tiongkok yaitu US$5,38 miliar,\r\ndisusul Amerika Serikat US$2,13 miliar dan India US$1,84 miliar, dengan kontribusi\r\nketiganya mencapai 45,20 persen. Sementara ekspor ke ASEAN dan Uni Eropa (27\r\nnegara) masing-masing sebesar US$3,82 miliar dan US$1,26 miliar.&lt;/span&gt;&lt;/li&gt;&lt;li&gt;&lt;span style=&quot;font-size: 10pt;&quot;&gt;Menurut provinsi asal barang, ekspor Indonesia terbesar pada Januari–Agustus\r\n2023 berasal dari Jawa Barat dengan nilai US$24,58 miliar (14,33 persen), diikuti\r\nKalimantan Timur US$19,25 miliar (11,23 persen) dan Jawa Timur US$14,36 miliar\r\n(8,37 persen).&lt;/span&gt;&lt;/li&gt;&lt;/ul&gt;&lt;/div&gt;&lt;div&gt;&lt;span style=&quot;font-size: 10pt;&quot;&gt;&lt;br&gt;&lt;/span&gt;&lt;/div&gt;&lt;div&gt;&lt;span style=&quot;font-size: 10pt;&quot;&gt;&lt;b&gt;B. PERKEMBANGAN IMPOR&lt;/b&gt;&lt;/span&gt;&lt;/div&gt;&lt;div&gt;&lt;ul&gt;&lt;li&gt;&lt;span style=&quot;font-size: 10pt;&quot;&gt;Nilai impor Indonesia Agustus 2023 mencapai US$18,88 miliar, turun 3,53 persen\r\ndibandingkan Juli 2023 dan turun 14,77 persen dibandingkan Agustus 2022.&lt;/span&gt;&lt;/li&gt;&lt;li&gt;&lt;span style=&quot;font-size: 10pt;&quot;&gt;Impor migas Agustus 2023 senilai US$2,66 miliar, turun 15,01 persen dibandingkan\r\nJuli 2023 dan turun 28,08 persen dibandingkan Agustus 2022. Impor nonmigas Agustus 2023 senilai US$16,22 miliar, turun 1,34 persen\r\ndibandingkan Juli 2023 dan turun 12,10 persen dibandingkan Agustus 2022.&amp;nbsp;&lt;/span&gt;&lt;/li&gt;&lt;li&gt;&lt;span style=&quot;font-size: 10pt;&quot;&gt;Penurunan impor golongan barang nonmigas terbesar Agustus 2023 dibandingkan\r\nJuli 2023 adalah kapal, perahu, dan struktur terapung senilai US$198,0 juta (62,31\r\npersen). Sementara peningkatan terbesar adalah ampas dan industri makanan\r\nUS$138,7 juta (42,59 persen).&lt;/span&gt;&lt;/li&gt;&lt;li&gt;&lt;span style=&quot;font-size: 10pt;&quot;&gt;Tiga negara pemasok barang impor nonmigas terbesar selama Januari–Agustus\r\n2023 adalah Tiongkok US$40,72 miliar (32,65 persen), Jepang US$11,15 miliar\r\n(8,94 persen), dan Thailand US$6,95 miliar (5,57 persen). Impor nonmigas dari\r\nASEAN US$20,62 miliar (16,53 persen) dan Uni Eropa US$9,65 miliar (7,74 persen).&lt;/span&gt;&lt;/li&gt;&lt;li&gt;&lt;span style=&quot;font-size: 10pt;&quot;&gt;Menurut golongan penggunaan barang, nilai impor Januari–Agustus 2023 terhadap\r\nperiode yang sama tahun sebelumnya terjadi peningkatan pada golongan barang\r\nmodal senilai US$2.740,2 juta (11,85 persen) dan barang konsumsi US$996,2 juta\r\n(7,66 persen). Sementara impor bahan baku/penolong turun US$16.236,6 juta\r\n(13,14 persen).&lt;/span&gt;&lt;/li&gt;&lt;li&gt;&lt;span style=&quot;font-size: 10pt;&quot;&gt;Neraca perdagangan Indonesia Agustus 2023 mengalami surplus US$3,12 miliar\r\nterutama berasal dari sektor nonmigas US$4,46 miliar, namun tereduksi oleh\r\ndefisit sektor migas senilai US$1,34 miliar.&lt;/span&gt;&lt;/li&gt;&lt;/ul&gt;&lt;/div&gt;",
+                "rl_date": "2023-09-15",
+                "updt_date": null,
+                "pdf": "https://www.bps.go.id/pressrelease/downloadapi.html?data=vwTrE4VJJQgeVClfOYH4KC6VEPFuIoFa8L+GT9uKpJ1U5nUkZBpvPNiVWpq5hhClqWEfeMiza7R1XVXLtsTyOg==",
+                "size": "6.04 MB",
+                "slide": "https://www.bps.go.id/website/materi_ind/materiBrsInd-20230915103633.pdf",
+                "thumbnail": "https://www.bps.go.id/website/images/Ekspor-Impor--Agustus-2023-ind.jpeg"
+            },
+            {
+                "brs_id": 2011,
+                "subj_id": 20,
+                "subj": "Harga Perdagangan Besar",
+                "title": "Pada Agustus 2023, perubahan Indeks Harga Perdagangan Besar (IHPB) Umum Nasional tahun ke tahun sebesar 3,72 persen.",
+                "abstract": "&lt;ul style=&quot;box-sizing: border-box; margin-top: 0px; margin-bottom: 10px; color: rgb(51, 51, 51); font-family: &amp;quot;Helvetica Neue&amp;quot;, Helvetica, Arial, sans-serif; font-size: 14px;&quot;&gt;&lt;li data-mce-style=&quot;text-align: justify;&quot; style=&quot;box-sizing: border-box; text-align: justify;&quot;&gt;Pada Agustus 2023, perubahan Indeks Harga Perdagangan Besar (IHPB) Umum Nasional tahun ke tahun (y-on-y) sebesar 3,72 persen terhadap IHPB Agustus 2022. Kenaikan IHPB tertinggi terjadi pada Sektor Pertanian, yaitu sebesar 5,18 persen.&lt;/li&gt;&lt;li data-mce-style=&quot;text-align: justify;&quot; style=&quot;box-sizing: border-box; text-align: justify;&quot;&gt;Beberapa komoditas yang mengalami kenaikan harga tahun ke tahun (y-on-y) pada Agustus 2023 antara lain: bawang putih, padi, pasir, beras, rokok kretek dengan filter, dan bensin.&lt;/li&gt;&lt;li data-mce-style=&quot;text-align: justify;&quot; style=&quot;box-sizing: border-box; text-align: justify;&quot;&gt;Perubahan IHPB bulan ke bulan (m-to-m) Agustus 2023 sebesar 0,04 persen dan perubahan IHPB tahun kalender (y-to-d) Agustus 2023 sebesar 1,83 persen.&lt;/li&gt;&lt;li data-mce-style=&quot;text-align: justify;&quot; style=&quot;box-sizing: border-box; text-align: justify;&quot;&gt;Perubahan IHPB Bahan Bangunan/Konstruksi tahun ke tahun (y-on-y) Agustus 2023 sebesar 2,13 persen terhadap Agustus 2022, antara lain disebabkan oleh kenaikan harga komoditas pasir, batu fondasi bangunan, batu split, semen, solar, dan aspal.&lt;/li&gt;&lt;/ul&gt;",
+                "rl_date": "2023-09-01",
+                "updt_date": null,
+                "pdf": "https://www.bps.go.id/pressrelease/downloadapi.html?data=8NLmyO6E3J1C4ZW2DF+0f2nKrqnnSdndsePL7+rYkT/xHHhOqVrcjn46vEimUCplpG23G0gTZN+FqHwHCddkbQ==",
+                "size": "3.92 MB",
+                "slide": "https://www.bps.go.id/website/materi_ind/materiBrsInd-20230901105706.pdf",
+                "thumbnail": "https://www.bps.go.id/website/images/IHPB-Agustus-2023-ind.jpg"
+            }
+        ]
+    ]
+}

--- a/test/fixtures/subject_category_list_fixture.json
+++ b/test/fixtures/subject_category_list_fixture.json
@@ -1,0 +1,31 @@
+{
+    "status": "OK",
+    "data-availability": "available",
+    "data": [
+        {
+            "page": 1,
+            "pages": 1,
+            "per_page": 10,
+            "count": 4,
+            "total": 4
+        },
+        [
+            {
+                "subcat_id": 0,
+                "title": "Lainnya"
+            },
+            {
+                "subcat_id": 1,
+                "title": "Sosial dan Kependudukan"
+            },
+            {
+                "subcat_id": 2,
+                "title": "Ekonomi dan Perdagangan"
+            },
+            {
+                "subcat_id": 3,
+                "title": "Pertanian dan Pertambangan"
+            }
+        ]
+    ]
+}

--- a/test/fixtures/subject_list_fixture.json
+++ b/test/fixtures/subject_list_fixture.json
@@ -1,0 +1,36 @@
+{
+    "status": "OK",
+    "data-availability": "available",
+    "data": [
+        {
+            "page": 1,
+            "pages": 5,
+            "per_page": 10,
+            "count": 3,
+            "total": 3
+        },
+        [
+            {
+                "sub_id": 40,
+                "title": "Gender",
+                "subcat_id": 1,
+                "subcat": "Sosial dan Kependudukan",
+                "ntabel": null
+            },
+            {
+                "sub_id": 153,
+                "title": "Geografi",
+                "subcat_id": 1,
+                "subcat": "Sosial dan Kependudukan",
+                "ntabel": null
+            },
+            {
+                "sub_id": 151,
+                "title": "Iklim",
+                "subcat_id": 1,
+                "subcat": "Sosial dan Kependudukan",
+                "ntabel": null
+            }
+        ]
+    ]
+}

--- a/test/src/core/network/api_endpoint_test.dart
+++ b/test/src/core/network/api_endpoint_test.dart
@@ -648,4 +648,258 @@ void main() {
       );
     },
   );
+
+  group(
+    'subjectCategories',
+    () {
+      test(
+        'should return subject categories endpoint with its default param',
+        () {
+          final result = ApiEndpoint.subjectCategories(domain: '7200');
+          expect(
+            result,
+            equals('model/subcat?page=1&domain=7200&lang=ind'),
+          );
+        },
+      );
+
+      test(
+        'should using correct lang when it set on param',
+        () {
+          final result = ApiEndpoint.subjectCategories(
+            domain: '7200',
+            lang: DataLanguage.en,
+          );
+          expect(
+            result,
+            equals('model/subcat?page=1&domain=7200&lang=eng'),
+          );
+        },
+      );
+
+      test(
+        'should using correct page when it set on param',
+        () {
+          final result = ApiEndpoint.subjectCategories(
+            domain: '7200',
+            page: 2,
+          );
+          expect(
+            result,
+            equals('model/subcat?page=2&domain=7200&lang=ind'),
+          );
+        },
+      );
+    },
+  );
+
+  group(
+    'subjects',
+    () {
+      test(
+        'should return subject endpoint with its default param',
+        () {
+          final result = ApiEndpoint.subjects(domain: '7200');
+          expect(
+            result,
+            equals('model/subject?domain=7200&lang=ind&page=1'),
+          );
+        },
+      );
+
+      test(
+        'should using correct lang when it set on param',
+        () {
+          final result = ApiEndpoint.subjects(
+            domain: '7200',
+            lang: DataLanguage.en,
+          );
+          expect(
+            result,
+            equals('model/subject?domain=7200&lang=eng&page=1'),
+          );
+        },
+      );
+
+      test(
+        'should using correct page when it set on param',
+        () {
+          final result = ApiEndpoint.subjects(
+            domain: '7200',
+            page: 2,
+          );
+          expect(
+            result,
+            equals('model/subject?domain=7200&lang=ind&page=2'),
+          );
+        },
+      );
+
+      test(
+        'should using correct subjectCategoryId when it set on param',
+        () {
+          final result = ApiEndpoint.subjects(
+            domain: '7200',
+            subjectCategoryId: 1,
+          );
+          expect(
+            result,
+            equals('model/subject?domain=7200&lang=ind&page=1&subcat=1'),
+          );
+        },
+      );
+    },
+  );
+
+  group(
+    'pressReleases',
+    () {
+      test(
+        'should return press release endpoint with its default param',
+        () {
+          final result = ApiEndpoint.pressReleases(domain: '7200');
+          expect(
+            result,
+            equals('model/pressrelease?domain=7200&page=1&lang=ind'),
+          );
+        },
+      );
+
+      test(
+        'should using correct lang when it set on param',
+        () {
+          final result = ApiEndpoint.pressReleases(
+            domain: '7200',
+            lang: DataLanguage.en,
+          );
+          expect(
+            result,
+            equals('model/pressrelease?domain=7200&page=1&lang=eng'),
+          );
+        },
+      );
+
+      test(
+        'should using correct page when it set on param',
+        () {
+          final result = ApiEndpoint.pressReleases(
+            domain: '7200',
+            page: 2,
+          );
+          expect(
+            result,
+            equals('model/pressrelease?domain=7200&page=2&lang=ind'),
+          );
+        },
+      );
+
+      test(
+        'should not include keyword in param if its exist and  empty',
+        () {
+          final result = ApiEndpoint.pressReleases(
+            domain: '7200',
+            keyword: '',
+          );
+          expect(
+            result,
+            equals('model/pressrelease?domain=7200&page=1&lang=ind'),
+          );
+        },
+      );
+
+      test(
+        'should include keyword in param if its exist and not empty',
+        () {
+          final result = ApiEndpoint.pressReleases(
+            domain: '7200',
+            keyword: 'Keyword',
+          );
+          expect(
+            result,
+            equals(
+              'model/pressrelease?domain=7200&page=1&lang=ind&keyword=Keyword',
+            ),
+          );
+        },
+      );
+
+      test(
+        'should include month in param if its ',
+        () {
+          final result = ApiEndpoint.pressReleases(
+            domain: '7200',
+            month: 12,
+          );
+          expect(
+            result,
+            equals('model/pressrelease?domain=7200&page=1&lang=ind&month=12'),
+          );
+        },
+      );
+
+      test(
+        'should include month and pad left with 0 in param if its single ',
+        () {
+          final result = ApiEndpoint.pressReleases(
+            domain: '7200',
+            month: 2,
+          );
+          expect(
+            result,
+            equals('model/pressrelease?domain=7200&page=1&lang=ind&month=02'),
+          );
+        },
+      );
+
+      test(
+        'should include year in param ',
+        () {
+          final result = ApiEndpoint.pressReleases(
+            domain: '7200',
+            year: 2023,
+          );
+          expect(
+            result,
+            equals('model/pressrelease?domain=7200&page=1&lang=ind&year=2023'),
+          );
+        },
+      );
+    },
+  );
+
+  group(
+    'pressReleaseDetail',
+    () {
+      test(
+        'should return press release detail endpoint with default param',
+        () {
+          final result = ApiEndpoint.pressReleaseDetail(
+            id: 1234,
+            domain: '7200',
+          );
+
+          expect(
+            result,
+            equals('model/pressrelease?id=1234&domain=7200&lang=ind'),
+          );
+        },
+      );
+
+      test(
+        'should return publication endpoint with correct lang param',
+        () {
+          final result = ApiEndpoint.pressReleaseDetail(
+            id: 1234,
+            domain: '7200',
+            lang: DataLanguage.en,
+          );
+
+          expect(
+            result,
+            equals('model/pressrelease?id=1234&domain=7200&lang=eng'),
+          );
+        },
+      );
+    },
+  );
 }

--- a/test/src/features/press_releases/data/datasources/press_release_remote_data_source_test.dart
+++ b/test/src/features/press_releases/data/datasources/press_release_remote_data_source_test.dart
@@ -1,0 +1,220 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:stadata_flutter_sdk/src/core/network/api_endpoint.dart';
+import 'package:stadata_flutter_sdk/src/core/network/http/modules/stadata_list_http_module.dart';
+import 'package:stadata_flutter_sdk/src/core/network/http/modules/stadata_view_http_module.dart';
+import 'package:stadata_flutter_sdk/src/core/typedef/typedef.dart';
+import 'package:stadata_flutter_sdk/src/features/press_releases/data/datasources/press_release_remote_data_source.dart';
+import 'package:stadata_flutter_sdk/src/features/press_releases/data/models/press_release_model.dart';
+import 'package:stadata_flutter_sdk/src/shared/data/models/api_response_model.dart';
+import 'package:stadata_flutter_sdk/stadata_flutter_sdk.dart';
+
+import '../../../../../fixtures/fixtures.dart';
+import '../../../../../helpers/test_injection.dart';
+
+class MockStadataListHttpModule extends Mock implements StadataListHttpModule {}
+
+class MockStadataViewHttpModule extends Mock implements StadataViewHttpModule {}
+
+void main() {
+  late StadataListHttpModule mockListHttpModule;
+  late StadataViewHttpModule mockViewHttpModule;
+  late PressReleaseRemoteDataSource dataSource;
+
+  setUpAll(
+    () {
+      mockListHttpModule = MockStadataListHttpModule();
+      registerTestLazySingleton<StadataListHttpModule>(mockListHttpModule);
+      mockViewHttpModule = MockStadataViewHttpModule();
+      registerTestLazySingleton<StadataViewHttpModule>(mockViewHttpModule);
+      dataSource = PressReleaseRemoteDataSourceImpl();
+    },
+  );
+
+  tearDownAll(unregisterTestInjection);
+
+  const domain = '7200';
+
+  group(
+    'PressReleaseRemoteDataSource',
+    () {
+      group(
+        'get()',
+        () {
+          late ApiResponseModel<List<PressReleaseModel>?> data;
+          late JSON response;
+          late JSON unavailableResponse;
+          setUp(
+            () {
+              response = jsonFromFixture(Fixture.pressReleases.value);
+              unavailableResponse = jsonFromFixture(
+                Fixture.listUnavailable.value,
+              );
+
+              data = ApiResponseModel<List<PressReleaseModel>?>.fromJson(
+                response,
+                (json) {
+                  if (json == null || json is! List) {
+                    return null;
+                  }
+
+                  return json
+                      .map((e) => PressReleaseModel.fromJson(e as JSON))
+                      .toList();
+                },
+              );
+            },
+          );
+          test(
+            'should return list of press releases if success',
+            () async {
+              // arrange
+              when(
+                () => mockListHttpModule
+                    .get(ApiEndpoint.pressReleases(domain: domain)),
+              ).thenAnswer((_) async => response);
+
+              // act
+              final result = await dataSource.get(domain: domain);
+
+              // assert
+              expect(result, equals(data));
+              verify(
+                () => mockListHttpModule
+                    .get(ApiEndpoint.pressReleases(domain: domain)),
+              ).called(1);
+            },
+          );
+
+          test(
+            'should throw PressReleaseNotAvailable when list-not-available',
+            () async {
+              when(
+                () => mockListHttpModule.get(
+                  ApiEndpoint.pressReleases(
+                    domain: domain,
+                  ),
+                ),
+              ).thenAnswer(
+                (_) async => unavailableResponse,
+              );
+
+              final result = dataSource.get(domain: domain);
+
+              await expectLater(
+                result,
+                throwsA(
+                  const PressReleaseNotAvailableException(),
+                ),
+              );
+              verify(
+                () => mockListHttpModule.get(
+                  ApiEndpoint.pressReleases(
+                    domain: domain,
+                  ),
+                ),
+              ).called(1);
+            },
+          );
+        },
+      );
+
+      group(
+        'detail()',
+        () {
+          const id = 1234;
+
+          late JSON response;
+          late JSON unavailableResponse;
+          late ApiResponseModel<PressReleaseModel?> data;
+
+          setUp(
+            () {
+              response = jsonFromFixture(Fixture.pressReleaseDetail.value);
+              unavailableResponse = jsonFromFixture(Fixture.unavailable.value);
+              data = ApiResponseModel<PressReleaseModel?>.fromJson(
+                response,
+                (json) {
+                  if (json == null) {
+                    return null;
+                  }
+
+                  return PressReleaseModel.fromJson(json as JSON);
+                },
+              );
+            },
+          );
+
+          test(
+            'should return an instance of press release if success',
+            () async {
+              // arrange
+              when(
+                () => mockViewHttpModule.get(
+                  ApiEndpoint.pressReleaseDetail(
+                    id: id,
+                    domain: domain,
+                  ),
+                ),
+              ).thenAnswer((_) async => response);
+
+              // act
+              final result = await dataSource.detail(
+                id: id,
+                domain: domain,
+              );
+
+              // assert
+              expect(result, equals(data));
+              verify(
+                () => mockViewHttpModule.get(
+                  ApiEndpoint.pressReleaseDetail(
+                    id: id,
+                    domain: domain,
+                  ),
+                ),
+              ).called(1);
+            },
+          );
+
+          test(
+            'should thrown a PressReleaseNotAvailableException when failed',
+            () async {
+              // arrange
+              when(
+                () => mockViewHttpModule.get(
+                  ApiEndpoint.pressReleaseDetail(
+                    id: id,
+                    domain: domain,
+                  ),
+                ),
+              ).thenAnswer((_) async => unavailableResponse);
+
+              // act
+              final result = dataSource.detail(
+                id: id,
+                domain: domain,
+              );
+
+              // assert
+              await expectLater(
+                result,
+                throwsA(
+                  const PressReleaseNotAvailableException(),
+                ),
+              );
+              verify(
+                () => mockViewHttpModule.get(
+                  ApiEndpoint.pressReleaseDetail(
+                    id: id,
+                    domain: domain,
+                  ),
+                ),
+              ).called(1);
+            },
+          );
+        },
+      );
+    },
+  );
+}

--- a/test/src/features/press_releases/data/repositories/press_release_repository_impl_test.dart
+++ b/test/src/features/press_releases/data/repositories/press_release_repository_impl_test.dart
@@ -1,0 +1,245 @@
+import 'package:dartz/dartz.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:stadata_flutter_sdk/src/core/failures/failures.dart';
+import 'package:stadata_flutter_sdk/src/core/typedef/typedef.dart';
+import 'package:stadata_flutter_sdk/src/features/press_releases/data/datasources/press_release_remote_data_source.dart';
+import 'package:stadata_flutter_sdk/src/features/press_releases/data/models/press_release_model.dart';
+import 'package:stadata_flutter_sdk/src/features/press_releases/data/repositories/press_release_repository_impl.dart';
+import 'package:stadata_flutter_sdk/src/features/press_releases/domain/repositories/press_release_repository.dart';
+import 'package:stadata_flutter_sdk/src/shared/data/models/api_response_model.dart';
+import 'package:stadata_flutter_sdk/src/shared/data/models/pagination_model.dart';
+import 'package:stadata_flutter_sdk/src/shared/domain/entities/api_response.dart';
+import 'package:stadata_flutter_sdk/stadata_flutter_sdk.dart';
+
+import '../../../../../fixtures/fixtures.dart';
+import '../../../../../helpers/test_injection.dart';
+
+class MockPressReleaseRemoteDataSource extends Mock
+    implements PressReleaseRemoteDataSource {}
+
+void main() {
+  late PressReleaseRemoteDataSource mockRemoteDataSource;
+  late PressReleaseRepository repository;
+
+  setUpAll(
+    () {
+      mockRemoteDataSource = MockPressReleaseRemoteDataSource();
+      registerTestLazySingleton<PressReleaseRemoteDataSource>(
+        mockRemoteDataSource,
+      );
+      repository = PressReleaseRepositoryImpl();
+    },
+  );
+
+  tearDownAll(unregisterTestInjection);
+
+  const domain = '7205';
+
+  group(
+    'PublicationRepositoryImpl',
+    () {
+      group(
+        'get()',
+        () {
+          late ApiResponseModel<List<PressReleaseModel>?> response;
+          late ApiResponse<List<PressRelease>> data;
+
+          setUp(
+            () {
+              final json = jsonFromFixture(Fixture.pressReleases.value);
+
+              response = ApiResponseModel<List<PressReleaseModel>?>.fromJson(
+                json,
+                (json) {
+                  if (json == null || json is! List) {
+                    return null;
+                  }
+                  return json
+                      .map((e) => PressReleaseModel.fromJson(e as JSON))
+                      .toList();
+                },
+              );
+
+              final responseData =
+                  response.data?.map((e) => e.toEntity()).toList();
+
+              data = ApiResponse<List<PressRelease>>(
+                status: response.status,
+                dataAvailability: response.dataAvailability,
+                data: responseData,
+                message: response.message,
+                pagination: response.pagination?.toEntity(),
+              );
+            },
+          );
+          test(
+            'should return List of Press Releases if success',
+            () async {
+              // arrange
+              when(
+                () => mockRemoteDataSource.get(
+                  domain: domain,
+                ),
+              ).thenAnswer((_) async => response);
+
+              // act
+              final result = await repository.get(domain: domain);
+
+              // assert
+              expect(
+                result,
+                equals(
+                  Right<Failure, ApiResponse<List<PressRelease>>>(
+                    data,
+                  ),
+                ),
+              );
+              verify(
+                () => mockRemoteDataSource.get(
+                  domain: domain,
+                ),
+              ).called(1);
+            },
+          );
+
+          test(
+            'should return Failure if exception occured',
+            () async {
+              // arrange
+              when(
+                () => mockRemoteDataSource.get(
+                  domain: domain,
+                ),
+              ).thenThrow(const PressReleaseNotAvailableException());
+
+              // act
+              final result = await repository.get(domain: domain);
+
+              // assert
+              expect(
+                result,
+                equals(
+                  const Left<Failure, ApiResponse<List<PressRelease>>>(
+                    PressReleaseFailure(
+                      message:
+                          'StadataException - Press Release not available!',
+                    ),
+                  ),
+                ),
+              );
+              verify(
+                () => mockRemoteDataSource.get(
+                  domain: domain,
+                ),
+              ).called(1);
+            },
+          );
+        },
+      );
+
+      const id = 1234;
+
+      group(
+        'detail()',
+        () {
+          late ApiResponseModel<PressReleaseModel?> response;
+          late ApiResponse<PressRelease> data;
+          setUp(
+            () {
+              final jsonDetail = jsonFromFixture(
+                Fixture.pressReleaseDetail.value,
+              );
+
+              response = ApiResponseModel<PressReleaseModel?>.fromJson(
+                jsonDetail,
+                (json) {
+                  if (json == null) {
+                    return null;
+                  }
+
+                  return PressReleaseModel.fromJson(json as JSON);
+                },
+              );
+
+              data = ApiResponse<PressRelease>(
+                status: response.status,
+                dataAvailability: response.dataAvailability,
+                data: response.data?.toEntity(),
+                pagination: response.pagination?.toEntity(),
+                message: response.message,
+              );
+            },
+          );
+          test(
+            'should return an instance of PressRelease if success',
+            () async {
+              // arrange
+              when(
+                () => mockRemoteDataSource.detail(
+                  id: id,
+                  domain: domain,
+                ),
+              ).thenAnswer((_) async => response);
+
+              // act
+              final result = await repository.detail(
+                id: id,
+                domain: domain,
+              );
+
+              // assert
+              expect(
+                result,
+                equals(
+                  Right<Failure, ApiResponse<PressRelease>>(data),
+                ),
+              );
+              verify(
+                () => mockRemoteDataSource.detail(
+                  id: id,
+                  domain: domain,
+                ),
+              ).called(1);
+            },
+          );
+
+          test(
+            'should return Failure if exception occured',
+            () async {
+              // arrange
+              when(
+                () => mockRemoteDataSource.detail(
+                  id: id,
+                  domain: domain,
+                ),
+              ).thenThrow(const PressReleaseNotAvailableException());
+
+              // act
+              final result = await repository.detail(id: id, domain: domain);
+
+              // assert
+              expect(
+                result,
+                equals(
+                  const Left<Failure, ApiResponse<Publication>>(
+                    PressReleaseFailure(
+                      message:
+                          'StadataException - Press Release not available!',
+                    ),
+                  ),
+                ),
+              );
+              verify(
+                () => mockRemoteDataSource.detail(
+                  id: id,
+                  domain: domain,
+                ),
+              ).called(1);
+            },
+          );
+        },
+      );
+    },
+  );
+}

--- a/test/src/features/press_releases/domain/usecases/get_all_press_releases_test.dart
+++ b/test/src/features/press_releases/domain/usecases/get_all_press_releases_test.dart
@@ -1,0 +1,130 @@
+import 'package:dartz/dartz.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:stadata_flutter_sdk/src/core/failures/failures.dart';
+import 'package:stadata_flutter_sdk/src/core/typedef/typedef.dart';
+import 'package:stadata_flutter_sdk/src/features/press_releases/data/models/press_release_model.dart';
+import 'package:stadata_flutter_sdk/src/features/press_releases/domain/repositories/press_release_repository.dart';
+import 'package:stadata_flutter_sdk/src/features/press_releases/domain/usecases/get_all_press_releases.dart';
+import 'package:stadata_flutter_sdk/src/shared/data/models/api_response_model.dart';
+import 'package:stadata_flutter_sdk/src/shared/data/models/pagination_model.dart';
+import 'package:stadata_flutter_sdk/src/shared/domain/entities/api_response.dart';
+import 'package:stadata_flutter_sdk/stadata_flutter_sdk.dart';
+
+import '../../../../../fixtures/fixtures.dart';
+import '../../../../../helpers/test_injection.dart';
+
+class MockPressReleaseRepository extends Mock
+    implements PressReleaseRepository {}
+
+void main() {
+  late PressReleaseRepository mockRepository;
+  late GetAllPressReleases usecase;
+  late ApiResponse<List<PressRelease>> pressReleases;
+
+  setUpAll(
+    () {
+      mockRepository = MockPressReleaseRepository();
+      registerTestLazySingleton<PressReleaseRepository>(mockRepository);
+      usecase = GetAllPressReleases();
+
+      final jsonPublications = jsonFromFixture(
+        Fixture.pressReleases.value,
+      );
+
+      final publicationsResponse =
+          ApiResponseModel<List<PressReleaseModel>>.fromJson(
+        jsonPublications,
+        (json) {
+          if (json is! List) {
+            return [];
+          }
+
+          return json
+              .map((e) => PressReleaseModel.fromJson(e as JSON))
+              .toList();
+        },
+      );
+
+      final publicationsData =
+          publicationsResponse.data?.map((e) => e.toEntity()).toList() ?? [];
+
+      pressReleases = ApiResponse<List<PressRelease>>(
+        status: publicationsResponse.status,
+        dataAvailability: publicationsResponse.dataAvailability,
+        data: publicationsData,
+        message: publicationsResponse.message,
+        pagination: publicationsResponse.pagination?.toEntity(),
+      );
+    },
+  );
+
+  tearDownAll(unregisterTestInjection);
+
+  const domain = '7315';
+
+  group(
+    'GetAllPressReleases',
+    () {
+      test(
+        'should return list of press releases if call success',
+        () async {
+          when(
+            () => mockRepository.get(
+              domain: domain,
+            ),
+          ).thenAnswer((_) async => Right(pressReleases));
+
+          final result = await usecase(
+            const GetAllPressReleasesParam(
+              domain: domain,
+            ),
+          );
+
+          expect(
+            result,
+            Right<Failure, ApiResponse<List<PressRelease>>>(pressReleases),
+          );
+          verify(
+            () => mockRepository.get(
+              domain: domain,
+            ),
+          ).called(1);
+        },
+      );
+
+      test(
+        'should return failure if exception is thrown',
+        () async {
+          when(
+            () => mockRepository.get(
+              domain: domain,
+            ),
+          ).thenAnswer(
+            (_) async => const Left(
+              PressReleaseFailure(),
+            ),
+          );
+
+          final result = await usecase(
+            const GetAllPressReleasesParam(
+              domain: domain,
+            ),
+          );
+
+          expect(
+            result,
+            const Left<Failure, ApiResponse<List<PressRelease>>>(
+              PressReleaseFailure(),
+            ),
+          );
+          verify(
+            () => mockRepository.get(
+              domain: domain,
+            ),
+          ).called(1);
+        },
+      );
+    },
+  );
+}

--- a/test/src/features/press_releases/domain/usecases/get_detail_press_release_test.dart
+++ b/test/src/features/press_releases/domain/usecases/get_detail_press_release_test.dart
@@ -1,0 +1,128 @@
+// ignore_for_file: inference_failure_on_instance_creation
+
+import 'package:dartz/dartz.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+
+import 'package:stadata_flutter_sdk/src/core/failures/failures.dart';
+import 'package:stadata_flutter_sdk/src/core/typedef/typedef.dart';
+import 'package:stadata_flutter_sdk/src/features/press_releases/data/models/press_release_model.dart';
+import 'package:stadata_flutter_sdk/src/features/press_releases/domain/repositories/press_release_repository.dart';
+import 'package:stadata_flutter_sdk/src/features/press_releases/domain/usecases/get_detail_press_release.dart';
+import 'package:stadata_flutter_sdk/src/shared/data/models/api_response_model.dart';
+import 'package:stadata_flutter_sdk/src/shared/data/models/pagination_model.dart';
+import 'package:stadata_flutter_sdk/src/shared/domain/entities/api_response.dart';
+import 'package:stadata_flutter_sdk/stadata_flutter_sdk.dart';
+
+import '../../../../../fixtures/fixtures.dart';
+import '../../../../../helpers/test_injection.dart';
+
+class MockPressReleaseRepository extends Mock
+    implements PressReleaseRepository {}
+
+void main() {
+  late PressReleaseRepository mockRepository;
+  late GetDetailPressRelease usecase;
+
+  late ApiResponse<PressRelease> pressRelease;
+
+  setUpAll(
+    () {
+      mockRepository = MockPressReleaseRepository();
+      registerTestLazySingleton<PressReleaseRepository>(mockRepository);
+      usecase = GetDetailPressRelease();
+
+      final jsonPublication = jsonFromFixture(
+        Fixture.pressReleaseDetail.value,
+      );
+
+      final pressReleaseResponse =
+          ApiResponseModel<PressReleaseModel?>.fromJson(
+        jsonPublication,
+        (json) =>
+            json == null ? null : PressReleaseModel.fromJson(json as JSON),
+      );
+
+      pressRelease = ApiResponse<PressRelease>(
+        status: pressReleaseResponse.status,
+        dataAvailability: pressReleaseResponse.dataAvailability,
+        data: pressReleaseResponse.data?.toEntity(),
+        message: pressReleaseResponse.message,
+        pagination: pressReleaseResponse.pagination?.toEntity(),
+      );
+    },
+  );
+
+  tearDownAll(unregisterTestInjection);
+
+  const id = 1234;
+  const domain = '7315';
+
+  group(
+    'GetDetailPressRelease',
+    () {
+      test(
+        'should return instance of press release if call success',
+        () async {
+          when(
+            () => mockRepository.detail(
+              id: id,
+              domain: domain,
+            ),
+          ).thenAnswer((_) async => Right(pressRelease));
+
+          final result = await usecase(
+            const GetDetailPressReleaseParam(
+              id: id,
+              domain: domain,
+            ),
+          );
+
+          expect(result, Right(pressRelease));
+          verify(
+            () => mockRepository.detail(
+              id: id,
+              domain: domain,
+            ),
+          ).called(1);
+        },
+      );
+
+      test(
+        'should return failure if exception is thrown',
+        () async {
+          when(
+            () => mockRepository.detail(
+              id: id,
+              domain: domain,
+            ),
+          ).thenAnswer(
+            (_) async => const Left(
+              PressReleaseFailure(),
+            ),
+          );
+
+          final result = await usecase(
+            const GetDetailPressReleaseParam(
+              id: id,
+              domain: domain,
+            ),
+          );
+
+          expect(
+            result,
+            const Left(
+              PressReleaseFailure(),
+            ),
+          );
+          verify(
+            () => mockRepository.detail(
+              id: id,
+              domain: domain,
+            ),
+          ).called(1);
+        },
+      );
+    },
+  );
+}

--- a/test/src/features/subject_categories/data/datasources/subject_category_remote_data_source_test.dart
+++ b/test/src/features/subject_categories/data/datasources/subject_category_remote_data_source_test.dart
@@ -1,0 +1,116 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:stadata_flutter_sdk/src/core/network/api_endpoint.dart';
+
+import 'package:stadata_flutter_sdk/src/core/network/http/modules/stadata_list_http_module.dart';
+import 'package:stadata_flutter_sdk/src/core/typedef/typedef.dart';
+import 'package:stadata_flutter_sdk/src/features/subject_categories/data/datasources/subject_category_remote_data_source.dart';
+import 'package:stadata_flutter_sdk/src/features/subject_categories/data/models/subject_category_model.dart';
+import 'package:stadata_flutter_sdk/src/shared/data/models/api_response_model.dart';
+import 'package:stadata_flutter_sdk/stadata_flutter_sdk.dart';
+
+import '../../../../../fixtures/fixtures.dart';
+import '../../../../../helpers/test_injection.dart';
+
+class MockStadataListHttpModule extends Mock implements StadataListHttpModule {}
+
+void main() {
+  late StadataListHttpModule mockListHttpModule;
+  late SubjectCategoryRemoteDataSource dataSource;
+  late ApiResponseModel<List<SubjectCategoryModel>?> subjectCategories;
+  late JSON response;
+  late JSON unavailableResponse;
+
+  setUpAll(
+    () {
+      mockListHttpModule = MockStadataListHttpModule();
+      registerTestLazySingleton<StadataListHttpModule>(mockListHttpModule);
+      dataSource = SubjectCategoryRemoteDataSourceImpl();
+
+      response = jsonFromFixture(Fixture.subjectCategories.value);
+      unavailableResponse = jsonFromFixture(Fixture.listUnavailable.value);
+
+      subjectCategories =
+          ApiResponseModel<List<SubjectCategoryModel>?>.fromJson(
+        response,
+        (json) {
+          if (json == null || json is! List) {
+            return null;
+          }
+
+          return json
+              .map((e) => SubjectCategoryModel.fromJson(e as JSON))
+              .toList();
+        },
+      );
+    },
+  );
+
+  tearDownAll(unregisterTestInjection);
+
+  const domain = '7200';
+
+  group(
+    'DomainRemoteDataSource',
+    () {
+      group(
+        'get()',
+        () {
+          test(
+            'should return List of subject categories if success',
+            () async {
+              when(
+                () => mockListHttpModule.get(
+                  ApiEndpoint.subjectCategories(domain: domain),
+                ),
+              ).thenAnswer(
+                (_) async => response,
+              );
+
+              final result = await dataSource.get(domain: domain);
+
+              expect(result, equals(subjectCategories));
+              verify(
+                () => mockListHttpModule.get(
+                  ApiEndpoint.subjectCategories(domain: domain),
+                ),
+              ).called(1);
+            },
+          );
+
+          test(
+            'should throw SubjectCategoryNotAvailableException when '
+            'list-not-available',
+            () async {
+              when(
+                () => mockListHttpModule.get(
+                  ApiEndpoint.subjectCategories(
+                    domain: domain,
+                  ),
+                ),
+              ).thenAnswer(
+                (_) async => unavailableResponse,
+              );
+
+              final result = dataSource.get(domain: domain);
+
+              await expectLater(
+                result,
+                throwsA(
+                  const SubjectCategoryNotAvailableException(),
+                ),
+              );
+              verify(
+                () => mockListHttpModule.get(
+                  ApiEndpoint.subjectCategories(
+                    domain: domain,
+                  ),
+                ),
+              ).called(1);
+            },
+          );
+        },
+      );
+    },
+  );
+}

--- a/test/src/features/subject_categories/data/repositories/subject_category_repository_impl_test.dart
+++ b/test/src/features/subject_categories/data/repositories/subject_category_repository_impl_test.dart
@@ -1,0 +1,136 @@
+import 'package:dartz/dartz.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:stadata_flutter_sdk/src/core/failures/failures.dart';
+import 'package:stadata_flutter_sdk/src/core/typedef/typedef.dart';
+import 'package:stadata_flutter_sdk/src/features/subject_categories/data/datasources/subject_category_remote_data_source.dart';
+import 'package:stadata_flutter_sdk/src/features/subject_categories/data/models/subject_category_model.dart';
+import 'package:stadata_flutter_sdk/src/features/subject_categories/data/repositories/subject_category_repository_impl.dart';
+import 'package:stadata_flutter_sdk/src/features/subject_categories/domain/repositories/subject_category_repository.dart';
+import 'package:stadata_flutter_sdk/src/shared/data/models/api_response_model.dart';
+import 'package:stadata_flutter_sdk/src/shared/data/models/pagination_model.dart';
+import 'package:stadata_flutter_sdk/src/shared/domain/entities/api_response.dart';
+import 'package:stadata_flutter_sdk/stadata_flutter_sdk.dart';
+
+import '../../../../../fixtures/fixtures.dart';
+import '../../../../../helpers/test_injection.dart';
+
+class MockSubjectCategoryRemoteDataSource extends Mock
+    implements SubjectCategoryRemoteDataSource {}
+
+void main() {
+  late SubjectCategoryRemoteDataSource mockRemoteDataSource;
+  late SubjectCategoryRepository repository;
+  late ApiResponseModel<List<SubjectCategoryModel>?> successResponse;
+  late ApiResponse<List<SubjectCategory>> subjectCategories;
+
+  setUpAll(
+    () {
+      mockRemoteDataSource = MockSubjectCategoryRemoteDataSource();
+      registerTestLazySingleton<SubjectCategoryRemoteDataSource>(
+        mockRemoteDataSource,
+      );
+      repository = SubjectCategoryRepositoryImpl();
+      final json = jsonFromFixture(Fixture.subjectCategories.value);
+      successResponse = ApiResponseModel<List<SubjectCategoryModel>?>.fromJson(
+        json,
+        (json) {
+          if (json == null || json is! List) {
+            return null;
+          }
+
+          return json
+              .map((e) => SubjectCategoryModel.fromJson(e as JSON))
+              .toList();
+        },
+      );
+
+      final data = successResponse.data?.map((e) => e.toEntity()).toList();
+
+      subjectCategories = ApiResponse(
+        status: successResponse.status,
+        dataAvailability: successResponse.dataAvailability,
+        data: data,
+        message: successResponse.message,
+        pagination: successResponse.pagination?.toEntity(),
+      );
+    },
+  );
+
+  tearDownAll(unregisterTestInjection);
+
+  const domain = '7200';
+
+  group(
+    'SubjectCategoryRepositoryImpl',
+    () {
+      group(
+        'get()',
+        () {
+          test(
+            'should return list of subject categories if success',
+            () async {
+              // arrange
+              when(
+                () => mockRemoteDataSource.get(
+                  domain: domain,
+                ),
+              ).thenAnswer((_) async => successResponse);
+
+              // act
+              final result = await repository.get(domain: domain);
+
+              // assert
+              expect(
+                result,
+                equals(
+                  Right<Failure, ApiResponse<List<SubjectCategory>>>(
+                    subjectCategories,
+                  ),
+                ),
+              );
+              verify(
+                () => mockRemoteDataSource.get(
+                  domain: domain,
+                ),
+              ).called(1);
+            },
+          );
+
+          test(
+            'should return Failure if failed.',
+            () async {
+              // arrange
+              when(
+                () => mockRemoteDataSource.get(
+                  domain: domain,
+                ),
+              ).thenThrow(const SubjectCategoryNotAvailableException());
+
+              // act
+              final result = await repository.get(domain: domain);
+
+              // assert
+              expect(
+                result,
+                equals(
+                  const Left<Failure, ApiResponse<List<SubjectCategory>>>(
+                    SubjectCategoryFailure(
+                      message:
+                          'StadataException - Subject Category not available!',
+                    ),
+                  ),
+                ),
+              );
+              verify(
+                () => mockRemoteDataSource.get(
+                  domain: domain,
+                ),
+              ).called(1);
+            },
+          );
+        },
+      );
+    },
+  );
+}

--- a/test/src/features/subject_categories/domain/usecases/get_all_subject_categories_test.dart
+++ b/test/src/features/subject_categories/domain/usecases/get_all_subject_categories_test.dart
@@ -1,0 +1,129 @@
+import 'package:dartz/dartz.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:stadata_flutter_sdk/src/core/failures/failures.dart';
+import 'package:stadata_flutter_sdk/src/core/typedef/typedef.dart';
+import 'package:stadata_flutter_sdk/src/features/subject_categories/data/models/subject_category_model.dart';
+import 'package:stadata_flutter_sdk/src/features/subject_categories/domain/repositories/subject_category_repository.dart';
+import 'package:stadata_flutter_sdk/src/features/subject_categories/domain/usecases/get_all_subject_categories.dart';
+import 'package:stadata_flutter_sdk/src/shared/data/models/api_response_model.dart';
+import 'package:stadata_flutter_sdk/src/shared/data/models/pagination_model.dart';
+import 'package:stadata_flutter_sdk/src/shared/domain/entities/api_response.dart';
+import 'package:stadata_flutter_sdk/stadata_flutter_sdk.dart';
+
+import '../../../../../fixtures/fixtures.dart';
+import '../../../../../helpers/test_injection.dart';
+
+class MockSubjectCategoryRepository extends Mock
+    implements SubjectCategoryRepository {}
+
+void main() {
+  late SubjectCategoryRepository mockRepository;
+  late GetAllSubjectCategories usecase;
+  late ApiResponse<List<SubjectCategory>> data;
+
+  setUpAll(
+    () {
+      mockRepository = MockSubjectCategoryRepository();
+      registerTestLazySingleton<SubjectCategoryRepository>(mockRepository);
+      usecase = GetAllSubjectCategories();
+
+      final json = jsonFromFixture(Fixture.subjectCategories.value);
+      final response = ApiResponseModel<List<SubjectCategoryModel>?>.fromJson(
+        json,
+        (json) {
+          if (json == null || json is! List) {
+            return null;
+          }
+
+          return json
+              .map((e) => SubjectCategoryModel.fromJson(e as JSON))
+              .toList();
+        },
+      );
+
+      final dataResponse =
+          response.data?.map((e) => e.toEntity()).toList() ?? [];
+      data = ApiResponse<List<SubjectCategory>>(
+        data: dataResponse,
+        status: response.status,
+        message: response.message,
+        pagination: response.pagination?.toEntity(),
+        dataAvailability: response.dataAvailability,
+      );
+    },
+  );
+
+  tearDownAll(unregisterTestInjection);
+
+  const domain = '7315';
+
+  group(
+    'GetAllSubjectCategories',
+    () {
+      test(
+        'should return list of subject categories if call success',
+        () async {
+          // arrange
+          when(
+            () => mockRepository.get(domain: domain),
+          ).thenAnswer((_) async => Right(data));
+
+          // act
+          final result = await usecase(
+            const GetAllSubjectCategoriesParam(
+              domain: domain,
+            ),
+          );
+
+          // assert
+          expect(
+            result,
+            equals(
+              Right<Failure, ApiResponse<List<SubjectCategory>>>(data),
+            ),
+          );
+          verify(
+            () => mockRepository.get(domain: domain),
+          ).called(1);
+        },
+      );
+
+      test(
+        'should return failure if exception if failed ',
+        () async {
+          // arrange
+          when(
+            () => mockRepository.get(
+              domain: domain,
+            ),
+          ).thenAnswer(
+            (_) async => const Left(
+              SubjectCategoryFailure(),
+            ),
+          );
+
+          // act
+          final result = await usecase(
+            const GetAllSubjectCategoriesParam(
+              domain: domain,
+            ),
+          );
+
+          // assert
+          expect(
+            result,
+            equals(
+              const Left<Failure, ApiResponse<List<SubjectCategory>>>(
+                SubjectCategoryFailure(),
+              ),
+            ),
+          );
+          verify(
+            () => mockRepository.get(domain: domain),
+          );
+        },
+      );
+    },
+  );
+}

--- a/test/src/features/subjects/data/datasources/subject_remote_data_source_test.dart
+++ b/test/src/features/subjects/data/datasources/subject_remote_data_source_test.dart
@@ -1,11 +1,10 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:stadata_flutter_sdk/src/core/network/api_endpoint.dart';
-
 import 'package:stadata_flutter_sdk/src/core/network/http/modules/stadata_list_http_module.dart';
 import 'package:stadata_flutter_sdk/src/core/typedef/typedef.dart';
-import 'package:stadata_flutter_sdk/src/features/subject_categories/data/datasources/subject_category_remote_data_source.dart';
-import 'package:stadata_flutter_sdk/src/features/subject_categories/data/models/subject_category_model.dart';
+import 'package:stadata_flutter_sdk/src/features/subjects/data/datasources/subject_remote_data_source.dart';
+import 'package:stadata_flutter_sdk/src/features/subjects/data/models/subject_model.dart';
 import 'package:stadata_flutter_sdk/src/shared/data/models/api_response_model.dart';
 import 'package:stadata_flutter_sdk/stadata_flutter_sdk.dart';
 
@@ -16,52 +15,51 @@ class MockStadataListHttpModule extends Mock implements StadataListHttpModule {}
 
 void main() {
   late StadataListHttpModule mockListHttpModule;
-  late SubjectCategoryRemoteDataSource dataSource;
-  late ApiResponseModel<List<SubjectCategoryModel>?> subjectCategories;
+  late SubjectRemoteDataSource dataSource;
+  late ApiResponseModel<List<SubjectModel>?> subjects;
   late JSON response;
   late JSON unavailableResponse;
 
   setUpAll(
     () {
       mockListHttpModule = MockStadataListHttpModule();
-      registerTestLazySingleton<StadataListHttpModule>(mockListHttpModule);
-      dataSource = SubjectCategoryRemoteDataSourceImpl();
+      registerTestLazySingleton<StadataListHttpModule>(
+        mockListHttpModule,
+      );
+      dataSource = SubjectModelRemoteDataSourceImpl();
 
-      response = jsonFromFixture(Fixture.subjectCategories.value);
+      response = jsonFromFixture(Fixture.subjects.value);
       unavailableResponse = jsonFromFixture(Fixture.listUnavailable.value);
 
-      subjectCategories =
-          ApiResponseModel<List<SubjectCategoryModel>?>.fromJson(
+      subjects = ApiResponseModel<List<SubjectModel>?>.fromJson(
         response,
         (json) {
           if (json == null || json is! List) {
             return null;
           }
 
-          return json
-              .map((e) => SubjectCategoryModel.fromJson(e as JSON))
-              .toList();
+          return json.map((e) => SubjectModel.fromJson(e as JSON)).toList();
         },
       );
     },
   );
 
-  tearDownAll(unregisterTestInjection);
+  tearDownAll(() => unregisterTestInjection);
 
   const domain = '7200';
 
   group(
-    'SubjectCategoryRemoteDataSource',
+    'SubjectRemoteDataSource',
     () {
       group(
         'get()',
         () {
           test(
-            'should return List of subject categories if success',
+            'should return List of subjects if success',
             () async {
               when(
                 () => mockListHttpModule.get(
-                  ApiEndpoint.subjectCategories(domain: domain),
+                  ApiEndpoint.subjects(domain: domain),
                 ),
               ).thenAnswer(
                 (_) async => response,
@@ -69,22 +67,22 @@ void main() {
 
               final result = await dataSource.get(domain: domain);
 
-              expect(result, equals(subjectCategories));
+              expect(result, equals(subjects));
               verify(
                 () => mockListHttpModule.get(
-                  ApiEndpoint.subjectCategories(domain: domain),
+                  ApiEndpoint.subjects(domain: domain),
                 ),
               ).called(1);
             },
           );
 
           test(
-            'should throw SubjectCategoryNotAvailableException when '
+            'should throw SubjectNotAvailableException when '
             'list-not-available',
             () async {
               when(
                 () => mockListHttpModule.get(
-                  ApiEndpoint.subjectCategories(
+                  ApiEndpoint.subjects(
                     domain: domain,
                   ),
                 ),
@@ -97,12 +95,12 @@ void main() {
               await expectLater(
                 result,
                 throwsA(
-                  const SubjectCategoryNotAvailableException(),
+                  const SubjectNotAvailableException(),
                 ),
               );
               verify(
                 () => mockListHttpModule.get(
-                  ApiEndpoint.subjectCategories(
+                  ApiEndpoint.subjects(
                     domain: domain,
                   ),
                 ),

--- a/test/src/features/subjects/data/repositories/subject_repository_impl_test.dart
+++ b/test/src/features/subjects/data/repositories/subject_repository_impl_test.dart
@@ -1,0 +1,133 @@
+import 'package:dartz/dartz.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:stadata_flutter_sdk/src/core/failures/failures.dart';
+import 'package:stadata_flutter_sdk/src/core/typedef/typedef.dart';
+import 'package:stadata_flutter_sdk/src/features/subjects/data/datasources/subject_remote_data_source.dart';
+import 'package:stadata_flutter_sdk/src/features/subjects/data/models/subject_model.dart';
+import 'package:stadata_flutter_sdk/src/features/subjects/data/repositories/subject_repository_impl.dart';
+import 'package:stadata_flutter_sdk/src/features/subjects/domain/repositories/subject_repository.dart';
+import 'package:stadata_flutter_sdk/src/shared/data/models/api_response_model.dart';
+import 'package:stadata_flutter_sdk/src/shared/data/models/pagination_model.dart';
+import 'package:stadata_flutter_sdk/src/shared/domain/entities/api_response.dart';
+import 'package:stadata_flutter_sdk/stadata_flutter_sdk.dart';
+
+import '../../../../../fixtures/fixtures.dart';
+import '../../../../../helpers/test_injection.dart';
+
+class MockSubjectRemoteDataSource extends Mock
+    implements SubjectRemoteDataSource {}
+
+void main() {
+  late SubjectRemoteDataSource mockRemoteDataSource;
+  late SubjectRepository repository;
+  late ApiResponseModel<List<SubjectModel>?> successResponse;
+  late ApiResponse<List<Subject>> subjects;
+
+  setUpAll(
+    () {
+      mockRemoteDataSource = MockSubjectRemoteDataSource();
+      registerTestLazySingleton<SubjectRemoteDataSource>(
+        mockRemoteDataSource,
+      );
+      repository = SubjectRepositoryImpl();
+      final json = jsonFromFixture(Fixture.subjects.value);
+      successResponse = ApiResponseModel<List<SubjectModel>?>.fromJson(
+        json,
+        (json) {
+          if (json == null || json is! List) {
+            return null;
+          }
+
+          return json.map((e) => SubjectModel.fromJson(e as JSON)).toList();
+        },
+      );
+
+      final data = successResponse.data?.map((e) => e.toEntity()).toList();
+
+      subjects = ApiResponse(
+        status: successResponse.status,
+        dataAvailability: successResponse.dataAvailability,
+        data: data,
+        message: successResponse.message,
+        pagination: successResponse.pagination?.toEntity(),
+      );
+    },
+  );
+
+  tearDownAll(unregisterTestInjection);
+
+  const domain = '7200';
+
+  group(
+    'SubjectRepositoryImpl',
+    () {
+      group(
+        'get()',
+        () {
+          test(
+            'should return list of subjects if success',
+            () async {
+              // arrange
+              when(
+                () => mockRemoteDataSource.get(
+                  domain: domain,
+                ),
+              ).thenAnswer((_) async => successResponse);
+
+              // act
+              final result = await repository.get(domain: domain);
+
+              // assert
+              expect(
+                result,
+                equals(
+                  Right<Failure, ApiResponse<List<Subject>>>(
+                    subjects,
+                  ),
+                ),
+              );
+              verify(
+                () => mockRemoteDataSource.get(
+                  domain: domain,
+                ),
+              ).called(1);
+            },
+          );
+
+          test(
+            'should return Failure if failed.',
+            () async {
+              // arrange
+              when(
+                () => mockRemoteDataSource.get(
+                  domain: domain,
+                ),
+              ).thenThrow(const SubjectNotAvailableException());
+
+              // act
+              final result = await repository.get(domain: domain);
+
+              // assert
+              expect(
+                result,
+                equals(
+                  const Left<Failure, ApiResponse<List<Subject>>>(
+                    SubjectFailure(
+                      message: 'StadataException - Subject not available!',
+                    ),
+                  ),
+                ),
+              );
+              verify(
+                () => mockRemoteDataSource.get(
+                  domain: domain,
+                ),
+              ).called(1);
+            },
+          );
+        },
+      );
+    },
+  );
+}

--- a/test/src/features/subjects/domain/usecases/get_all_subjects_test.dart
+++ b/test/src/features/subjects/domain/usecases/get_all_subjects_test.dart
@@ -1,0 +1,126 @@
+import 'package:dartz/dartz.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:stadata_flutter_sdk/src/core/failures/failures.dart';
+import 'package:stadata_flutter_sdk/src/core/typedef/typedef.dart';
+import 'package:stadata_flutter_sdk/src/features/subjects/data/models/subject_model.dart';
+import 'package:stadata_flutter_sdk/src/features/subjects/domain/repositories/subject_repository.dart';
+import 'package:stadata_flutter_sdk/src/features/subjects/domain/usecases/get_all_subjects.dart';
+import 'package:stadata_flutter_sdk/src/shared/data/models/api_response_model.dart';
+import 'package:stadata_flutter_sdk/src/shared/data/models/pagination_model.dart';
+import 'package:stadata_flutter_sdk/src/shared/domain/entities/api_response.dart';
+import 'package:stadata_flutter_sdk/stadata_flutter_sdk.dart';
+
+import '../../../../../fixtures/fixtures.dart';
+import '../../../../../helpers/test_injection.dart';
+
+class MockSubjectRepository extends Mock implements SubjectRepository {}
+
+void main() {
+  late SubjectRepository mockRepository;
+  late GetAllSubjects usecase;
+  late ApiResponse<List<Subject>> data;
+
+  setUpAll(
+    () {
+      mockRepository = MockSubjectRepository();
+      registerTestLazySingleton<SubjectRepository>(mockRepository);
+      usecase = GetAllSubjects();
+
+      final json = jsonFromFixture(Fixture.subjects.value);
+      final response = ApiResponseModel<List<SubjectModel>?>.fromJson(
+        json,
+        (json) {
+          if (json == null || json is! List) {
+            return null;
+          }
+
+          return json.map((e) => SubjectModel.fromJson(e as JSON)).toList();
+        },
+      );
+
+      final dataResponse =
+          response.data?.map((e) => e.toEntity()).toList() ?? [];
+      data = ApiResponse<List<Subject>>(
+        data: dataResponse,
+        status: response.status,
+        message: response.message,
+        pagination: response.pagination?.toEntity(),
+        dataAvailability: response.dataAvailability,
+      );
+    },
+  );
+
+  tearDownAll(unregisterTestInjection);
+
+  const domain = '7315';
+
+  group(
+    'GetAllSubjects',
+    () {
+      test(
+        'should return list of subjects if call success',
+        () async {
+          // arrange
+          when(
+            () => mockRepository.get(domain: domain),
+          ).thenAnswer((_) async => Right(data));
+
+          // act
+          final result = await usecase(
+            const GetAllSubjectsParam(
+              domain: domain,
+            ),
+          );
+
+          // assert
+          expect(
+            result,
+            equals(
+              Right<Failure, ApiResponse<List<Subject>>>(data),
+            ),
+          );
+          verify(
+            () => mockRepository.get(domain: domain),
+          ).called(1);
+        },
+      );
+
+      test(
+        'should return failure if exception if failed ',
+        () async {
+          // arrange
+          when(
+            () => mockRepository.get(
+              domain: domain,
+            ),
+          ).thenAnswer(
+            (_) async => const Left(
+              SubjectFailure(),
+            ),
+          );
+
+          // act
+          final result = await usecase(
+            const GetAllSubjectsParam(
+              domain: domain,
+            ),
+          );
+
+          // assert
+          expect(
+            result,
+            equals(
+              const Left<Failure, ApiResponse<List<Subject>>>(
+                SubjectFailure(),
+              ),
+            ),
+          );
+          verify(
+            () => mockRepository.get(domain: domain),
+          );
+        },
+      );
+    },
+  );
+}

--- a/test/src/list/list_test.dart
+++ b/test/src/list/list_test.dart
@@ -11,10 +11,16 @@ import 'package:stadata_flutter_sdk/src/features/news/data/models/news_model.dar
 import 'package:stadata_flutter_sdk/src/features/news/domain/usecases/get_all_news.dart';
 import 'package:stadata_flutter_sdk/src/features/news_categories/data/models/news_category_model.dart';
 import 'package:stadata_flutter_sdk/src/features/news_categories/domain/usecases/get_all_news_categories.dart';
+import 'package:stadata_flutter_sdk/src/features/press_releases/data/models/press_release_model.dart';
+import 'package:stadata_flutter_sdk/src/features/press_releases/domain/usecases/get_all_press_releases.dart';
 import 'package:stadata_flutter_sdk/src/features/publications/data/models/publication_model.dart';
 import 'package:stadata_flutter_sdk/src/features/publications/domain/usecases/get_all_publication.dart';
 import 'package:stadata_flutter_sdk/src/features/static_tables/data/models/static_table_model.dart';
 import 'package:stadata_flutter_sdk/src/features/static_tables/domain/usecases/get_all_static_tables.dart';
+import 'package:stadata_flutter_sdk/src/features/subject_categories/data/models/subject_category_model.dart';
+import 'package:stadata_flutter_sdk/src/features/subject_categories/domain/usecases/get_all_subject_categories.dart';
+import 'package:stadata_flutter_sdk/src/features/subjects/data/models/subject_model.dart';
+import 'package:stadata_flutter_sdk/src/features/subjects/domain/usecases/get_all_subjects.dart';
 import 'package:stadata_flutter_sdk/src/list/list.dart';
 import 'package:stadata_flutter_sdk/src/shared/data/models/api_response_model.dart';
 import 'package:stadata_flutter_sdk/src/shared/data/models/pagination_model.dart';
@@ -36,6 +42,13 @@ class MockGetAllNews extends Mock implements GetAllNews {}
 
 class MockGetAllNewsCategories extends Mock implements GetAllNewsCategories {}
 
+class MockGetAllSubjectCategories extends Mock
+    implements GetAllSubjectCategories {}
+
+class MockGetAllSubjects extends Mock implements GetAllSubjects {}
+
+class MockGetAllPressReleases extends Mock implements GetAllPressReleases {}
+
 void main() {
   late GetAllNews mockGetAllNews;
   late GetDomains mockGetDomains;
@@ -43,6 +56,9 @@ void main() {
   late GetAllInfographics mockGetAllInfographics;
   late GetAllStaticTables mockGetAllStaticTables;
   late GetAllNewsCategories mockGetAllNewsCategories;
+  late GetAllSubjectCategories mockGetAllSubjectCategories;
+  late GetAllSubjects mockGetAllSubjects;
+  late GetAllPressReleases mockGetAllPressReleases;
   late StadataList stadataList;
 
   setUpAll(
@@ -59,6 +75,14 @@ void main() {
       registerTestLazySingleton<GetAllStaticTables>(mockGetAllStaticTables);
       mockGetAllNewsCategories = MockGetAllNewsCategories();
       registerTestLazySingleton<GetAllNewsCategories>(mockGetAllNewsCategories);
+      mockGetAllSubjectCategories = MockGetAllSubjectCategories();
+      registerTestLazySingleton<GetAllSubjectCategories>(
+        mockGetAllSubjectCategories,
+      );
+      mockGetAllSubjects = MockGetAllSubjects();
+      registerTestLazySingleton<GetAllSubjects>(mockGetAllSubjects);
+      mockGetAllPressReleases = MockGetAllPressReleases();
+      registerTestLazySingleton<GetAllPressReleases>(mockGetAllPressReleases);
       stadataList = StadataListImpl();
     },
   );
@@ -603,6 +627,283 @@ void main() {
               verify(
                 () => mockGetAllNewsCategories(
                   const GetAllNewsCategoriesParam(domain: domain),
+                ),
+              );
+            },
+          );
+        },
+      );
+
+      group(
+        'subjectCategories()',
+        () {
+          late ApiResponse<List<SubjectCategory>> response;
+          late ListResult<SubjectCategory> data;
+          setUp(
+            () {
+              final json = jsonFromFixture(Fixture.subjectCategories.value);
+              final jsonResponse =
+                  ApiResponseModel<List<SubjectCategoryModel>?>.fromJson(
+                json,
+                (json) {
+                  if (json == null || json is! List) {
+                    return null;
+                  }
+
+                  return json
+                      .map((e) => SubjectCategoryModel.fromJson(e as JSON))
+                      .toList();
+                },
+              );
+              final dataResponse =
+                  jsonResponse.data?.map((e) => e.toEntity()).toList() ?? [];
+              response = ApiResponse(
+                data: dataResponse,
+                status: jsonResponse.status,
+                dataAvailability: jsonResponse.dataAvailability,
+                message: jsonResponse.message,
+                pagination: jsonResponse.pagination?.toEntity(),
+              );
+              data = ListResult<SubjectCategory>(
+                data: dataResponse,
+                pagination: jsonResponse.pagination?.toEntity(),
+              );
+            },
+          );
+          test(
+            'should return ListResult<SubjectCategory> when success',
+            () async {
+              when(
+                () => mockGetAllSubjectCategories(
+                  const GetAllSubjectCategoriesParam(domain: domain),
+                ),
+              ).thenAnswer((_) async => Right(response));
+
+              final result =
+                  await stadataList.subjectCategories(domain: domain);
+
+              expect(result, data);
+              verify(
+                () => mockGetAllSubjectCategories(
+                  const GetAllSubjectCategoriesParam(domain: domain),
+                ),
+              );
+            },
+          );
+
+          test(
+            'should throw Exception if failure occured',
+            () async {
+              when(
+                () => mockGetAllSubjectCategories(
+                  const GetAllSubjectCategoriesParam(domain: domain),
+                ),
+              ).thenAnswer(
+                (_) async => const Left(
+                  SubjectCategoryFailure(),
+                ),
+              );
+
+              expect(
+                () => stadataList.subjectCategories(domain: domain),
+                throwsA(
+                  isA<Exception>().having(
+                    (e) => e.toString(),
+                    'Exception message',
+                    'StadataException - Failed to load subject category data!',
+                  ),
+                ),
+              );
+              verify(
+                () => mockGetAllSubjectCategories(
+                  const GetAllSubjectCategoriesParam(domain: domain),
+                ),
+              );
+            },
+          );
+        },
+      );
+
+      group(
+        'subjects()',
+        () {
+          late ApiResponse<List<Subject>> response;
+          late ListResult<Subject> data;
+          setUp(
+            () {
+              final json = jsonFromFixture(Fixture.subjects.value);
+              final jsonResponse =
+                  ApiResponseModel<List<SubjectModel>?>.fromJson(
+                json,
+                (json) {
+                  if (json == null || json is! List) {
+                    return null;
+                  }
+
+                  return json
+                      .map((e) => SubjectModel.fromJson(e as JSON))
+                      .toList();
+                },
+              );
+              final dataResponse =
+                  jsonResponse.data?.map((e) => e.toEntity()).toList() ?? [];
+              response = ApiResponse(
+                data: dataResponse,
+                status: jsonResponse.status,
+                dataAvailability: jsonResponse.dataAvailability,
+                message: jsonResponse.message,
+                pagination: jsonResponse.pagination?.toEntity(),
+              );
+              data = ListResult<Subject>(
+                data: dataResponse,
+                pagination: jsonResponse.pagination?.toEntity(),
+              );
+            },
+          );
+          test(
+            'should return ListResult<Subject> when success',
+            () async {
+              when(
+                () => mockGetAllSubjects(
+                  const GetAllSubjectsParam(
+                    domain: domain,
+                  ),
+                ),
+              ).thenAnswer((_) async => Right(response));
+
+              final result = await stadataList.subjects(domain: domain);
+
+              expect(result, data);
+              verify(
+                () => mockGetAllSubjects(
+                  const GetAllSubjectsParam(
+                    domain: domain,
+                  ),
+                ),
+              );
+            },
+          );
+
+          test(
+            'should throw Exception if failure occured',
+            () async {
+              when(
+                () => mockGetAllSubjects(
+                  const GetAllSubjectsParam(
+                    domain: domain,
+                  ),
+                ),
+              ).thenAnswer(
+                (_) async => const Left(
+                  SubjectFailure(),
+                ),
+              );
+
+              expect(
+                () => stadataList.subjects(domain: domain),
+                throwsA(
+                  isA<Exception>().having(
+                    (e) => e.toString(),
+                    'Exception message',
+                    'StadataException - Failed to load subject data!',
+                  ),
+                ),
+              );
+              verify(
+                () => mockGetAllSubjects(
+                  const GetAllSubjectsParam(
+                    domain: domain,
+                  ),
+                ),
+              );
+            },
+          );
+        },
+      );
+
+      group(
+        'pressReleases()',
+        () {
+          late ApiResponse<List<PressRelease>> response;
+          late ListResult<PressRelease> data;
+
+          setUp(
+            () {
+              final json = jsonFromFixture(Fixture.pressReleases.value);
+              final jsonResponse =
+                  ApiResponseModel<List<PressReleaseModel>>.fromJson(
+                json,
+                (json) {
+                  if (json is! List) {
+                    return [];
+                  }
+
+                  return json
+                      .map((e) => PressReleaseModel.fromJson(e as JSON))
+                      .toList();
+                },
+              );
+              final responseData =
+                  jsonResponse.data?.map((e) => e.toEntity()).toList() ?? [];
+              response = ApiResponse(
+                data: responseData,
+                status: jsonResponse.status,
+                dataAvailability: jsonResponse.dataAvailability,
+                message: jsonResponse.message,
+                pagination: jsonResponse.pagination?.toEntity(),
+              );
+              data = ListResult<PressRelease>(
+                data: responseData,
+                pagination: response.pagination,
+              );
+            },
+          );
+          test(
+            'should return ListResult<PressRelease> when success',
+            () async {
+              when(
+                () => mockGetAllPressReleases(
+                  const GetAllPressReleasesParam(domain: domain),
+                ),
+              ).thenAnswer((_) async => Right(response));
+
+              final result = await stadataList.pressReleases(domain: domain);
+
+              expect(result, data);
+              verify(
+                () => mockGetAllPressReleases(
+                  const GetAllPressReleasesParam(domain: domain),
+                ),
+              );
+            },
+          );
+
+          test(
+            'should throw Exception if failure occured',
+            () async {
+              when(
+                () => mockGetAllPressReleases(
+                  const GetAllPressReleasesParam(domain: domain),
+                ),
+              ).thenAnswer(
+                (_) async => const Left(
+                  PressReleaseFailure(),
+                ),
+              );
+
+              expect(
+                () => stadataList.pressReleases(domain: domain),
+                throwsA(
+                  isA<Exception>().having(
+                    (e) => e.toString(),
+                    'Exception message',
+                    'StadataException - Failed to load press release data!',
+                  ),
+                ),
+              );
+              verify(
+                () => mockGetAllPressReleases(
+                  const GetAllPressReleasesParam(domain: domain),
                 ),
               );
             },

--- a/test/src/view/view_test.dart
+++ b/test/src/view/view_test.dart
@@ -5,6 +5,8 @@ import 'package:stadata_flutter_sdk/src/core/failures/failures.dart';
 import 'package:stadata_flutter_sdk/src/core/typedef/typedef.dart';
 import 'package:stadata_flutter_sdk/src/features/news/data/models/news_model.dart';
 import 'package:stadata_flutter_sdk/src/features/news/domain/usecases/get_detail_news.dart';
+import 'package:stadata_flutter_sdk/src/features/press_releases/data/models/press_release_model.dart';
+import 'package:stadata_flutter_sdk/src/features/press_releases/domain/usecases/get_detail_press_release.dart';
 import 'package:stadata_flutter_sdk/src/features/publications/data/models/publication_model.dart';
 import 'package:stadata_flutter_sdk/src/features/publications/domain/usecases/get_detail_publication.dart';
 import 'package:stadata_flutter_sdk/src/features/static_tables/data/models/static_table_model.dart';
@@ -24,10 +26,13 @@ class MockGetDetailStaticTable extends Mock implements GetDetailStaticTable {}
 
 class MockGetDetailNews extends Mock implements GetDetailNews {}
 
+class MockGetDetailPressRelease extends Mock implements GetDetailPressRelease {}
+
 void main() {
   late GetDetailNews mockGetDetailNews;
   late GetDetailPublication mockGetDetailPublication;
   late GetDetailStaticTable mockGetDetailStaticTable;
+  late GetDetailPressRelease mockGetDetailPressRelease;
   late StadataView stadataView;
 
   setUpAll(
@@ -38,6 +43,10 @@ void main() {
       registerTestLazySingleton<GetDetailPublication>(mockGetDetailPublication);
       mockGetDetailStaticTable = MockGetDetailStaticTable();
       registerTestLazySingleton<GetDetailStaticTable>(mockGetDetailStaticTable);
+      mockGetDetailPressRelease = MockGetDetailPressRelease();
+      registerTestLazySingleton<GetDetailPressRelease>(
+        mockGetDetailPressRelease,
+      );
       stadataView = StadataViewImpl();
     },
   );
@@ -282,6 +291,88 @@ void main() {
               verify(
                 () => mockGetDetailNews(
                   const GetDetailNewsParam(id: id, domain: domain),
+                ),
+              );
+            },
+          );
+        },
+      );
+
+      group(
+        'pressRelease()',
+        () {
+          late ApiResponse<PressRelease> response;
+          late PressRelease data;
+          setUp(
+            () {
+              final json = jsonFromFixture(Fixture.pressReleaseDetail.value);
+              final jsonResponse =
+                  ApiResponseModel<PressReleaseModel?>.fromJson(
+                json,
+                (json) => json == null
+                    ? null
+                    : PressReleaseModel.fromJson(json as JSON),
+              );
+              response = ApiResponse<PressRelease>(
+                data: jsonResponse.data?.toEntity(),
+                status: jsonResponse.status,
+                message: jsonResponse.message,
+                dataAvailability: jsonResponse.dataAvailability,
+                pagination: jsonResponse.pagination?.toEntity(),
+              );
+              data = jsonResponse.data!.toEntity();
+            },
+          );
+
+          const id = 1234;
+
+          test(
+            'should return an instance of Press Release when success',
+            () async {
+              when(
+                () => mockGetDetailPressRelease(
+                  const GetDetailPressReleaseParam(id: id, domain: domain),
+                ),
+              ).thenAnswer((_) async => Right(response));
+
+              final result =
+                  await stadataView.pressRelease(id: id, domain: domain);
+
+              expect(result, data);
+              verify(
+                () => mockGetDetailPressRelease(
+                  const GetDetailPressReleaseParam(id: id, domain: domain),
+                ),
+              );
+            },
+          );
+
+          test(
+            'should throw Exception if failure occured',
+            () async {
+              when(
+                () => mockGetDetailPressRelease(
+                  const GetDetailPressReleaseParam(id: id, domain: domain),
+                ),
+              ).thenAnswer(
+                (_) async => const Left(
+                  PressReleaseFailure(),
+                ),
+              );
+
+              expect(
+                () => stadataView.pressRelease(id: id, domain: domain),
+                throwsA(
+                  isA<Exception>().having(
+                    (e) => e.toString(),
+                    'Exception message',
+                    'StadataException - Failed to load press release data!',
+                  ),
+                ),
+              );
+              verify(
+                () => mockGetDetailPressRelease(
+                  const GetDetailPressReleaseParam(id: id, domain: domain),
                 ),
               );
             },


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Status

**READY**

## Add Subject Categories, Subjects, & Press Release Feature

### Description:

This pull request adds the ability to fetch subject categories, subjects, and press release data from the BPS (Badan Pusat Statistik) API to the stadata flutter SDK. It introduces the following major features:

- **Subject Categories**: Allows users to retrieve a list of subject categories. The news feature includes entities, repositories, use cases, models, serializers, fixtures, data sources, and tests for comprehensive coverage.

- **Subjects**: Provides functionality to fetch a list of subjects. Similar to the subject categories feature, it includes entities, repositories, use cases, models, serializers, fixtures, data sources, and tests.|

- **Press Release**: Allows users to retrieve a list of press release and view the details of individual press release. The press release feature includes entities, repositories, use cases, models, serializers, fixtures, data sources, and tests for comprehensive coverage.

The PR also includes documentation updates, test improvements, and code refactoring to ensure clean and maintainable code.

### Changes Made:

- Added subject categories, subjects, and press release features.
- Created entities, repositories, use cases, models, serializers, fixtures, and data sources for all features.
- Improved test coverage for various SDK features.
- Updated documentation for the new features.
- Refactored code for better organization and maintainability.

### How To Use

#### Subject Categories

To fetch subject categories data, users can now call an instance of `StadataFlutter` with `list` getter and use the new`subjectCategories` method. This provides access to different subject categories from the BPS API.

Example usage:

```dart
final result = await StadataFlutter.instance.list.subjectCategories(domain: '7200');
final subjectCategoryList = result.data;
final pagination = result.pagination;


// Print pagination info
print('Current Page: ${pagination.page}');
print('Total Pages: ${pagination.pages}');
print('Data Count in This Page: ${pagination.count}');
print('Per Page: ${pagination.perPage}');
print('Total: ${pagination.total}');
print('------------------------');

// Print the retrieved subject category data
for (final subjectCategory in subjectCategoryList) {
    print('Subject Category ID: ${subjectCategory.id}');
    print('Subject Category Name: ${subjectCategory.name}');
}
```


#### Subject

To fetch subject data, users can now call an instance of `StadataFlutter` with `list` getter and use the new`subjects` method. This provides access to different subjecs from the BPS API.

Example usage:

```dart
final result = await StadataFlutter.instance.list.subjects(domain: '7200');
final subjectList = result.data;
final pagination = result.pagination;


// Print pagination info
print('Current Page: ${pagination.page}');
print('Total Pages: ${pagination.pages}');
print('Data Count in This Page: ${pagination.count}');
print('Per Page: ${pagination.perPage}');
print('Total: ${pagination.total}');
print('------------------------');

// Print the retrieved subject data
for (final subject in subjectList) {
    print('Subject ID: ${subject.id}');
    print('Subject Name: ${subject.name}');
    print('Subject Category ID: ${subject.category?.id}');
    print('Subject Category Name: ${subject.category?.name}');
    print('Subject N Table: ${subject.nTable}');
}
```

#### Press Release

To fetch press release data, users can now call an instance of `StadataFlutter` with `list` getter and use the new `pressReleases` method to get list of news or use `view` getter with `pressRelease` method to get detail of news. This provides access to different press releases from the BPS API.

Example usage:
- List
```dart
final result = await StadataFlutter.instance.list.pressReleases(domain: '7200');
final pressReleaseList = result.data;
final pagination = result.pagination;


// Print pagination info
print('Current Page: ${pagination.page}');
print('Total Pages: ${pagination.pages}');
print('Data Count in This Page: ${pagination.count}');
print('Per Page: ${pagination.perPage}');
print('Total: ${pagination.total}');
print('------------------------');

// Print the retrieved press release data
for (final pressRelease in pressReleaseList) {
    print('Press Release ID: ${pressRelease.id}');
    print('Subject ID: ${pressRelease.subject?.id}');
    print('Subject Name: ${pressRelease.subject?.name}');
    print('Title: ${pressRelease.title}');
    print('Abstract: ${pressRelease.abstract}');
    print('Release Date: ${pressRelease.releaseDate}');
    print('Cover: ${pressRelease.cover}');
    print('File Size: ${pressRelease.size}');
    print('PDF Url: ${pressRelease.pdf}');
    print('Slide Url: ${pressRelease.slide}');
    print('Updated At: ${pressRelease.updatedAt}');
}
```

- View
```dart
final result = await StadataFlutter.instance.view.pressRelease(id: 1234:, domain: '7200');
final pressRelease = result.data;

// Print the retrieved press release data
print('Press Release ID: ${pressRelease.id}');
print('Title: ${pressRelease.title}');
print('Abstract: ${pressRelease.abstract}');
print('Release Date: ${pressRelease.releaseDate}');
print('Cover: ${pressRelease.cover}');
print('File Size: ${pressRelease.size}');
print('PDF Url: ${pressRelease.pdf}');
print('Slide Url: ${pressRelease.slide}');
print('Updated At: ${pressRelease.updatedAt}');
```


### Testing:

Extensive unit tests have been added to ensure the reliability and correctness of the new features. Existing tests for other SDK features have also been improved to enhance overall test coverage.

### Checklist:

- [x] New features or enhancements have been tested.
- [x] All tests pass successfully.
- [x] Documentation has been updated.
- [x] Code is clean and follows coding conventions.
- [x] PR is ready for review.


## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [x] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [x] 🗑️ Chore
