### PR TITLE
feat(view): add detail endpoints for 11 missing StadataView methods

### DIFF
--- a/packages/stadata_flutter_sdk/lib/src/features/derived_periods/data/datasources/derived_period_remote_data_source.dart
+++ b/packages/stadata_flutter_sdk/lib/src/features/derived_periods/data/datasources/derived_period_remote_data_source.dart
@@ -11,6 +11,11 @@ abstract class DerivedPeriodRemoteDataSource {
     DataLanguage lang = DataLanguage.id,
     int? variableID,
   });
+  Future<ApiResponseModel<DerivedPeriodModel?>> detail({
+    required int id,
+    required String domain,
+    DataLanguage lang = DataLanguage.id,
+  });
 }
 
 /// Implementation of [DerivedPeriodRemoteDataSource] that fetches data from BPS API.
@@ -19,6 +24,45 @@ class DerivedPeriodRemoteDataSourceImpl
   final NetworkClient _listHttpModule = injector.get<NetworkClient>(
     instanceName: InjectorConstant.listClient,
   );
+  final NetworkClient _detailClient = injector.get<NetworkClient>(
+    instanceName: InjectorConstant.viewClient,
+  );
+
+  @override
+  Future<ApiResponseModel<DerivedPeriodModel?>> detail({
+    required int id,
+    required String domain,
+    DataLanguage lang = DataLanguage.id,
+  }) async {
+    final result = await _detailClient.get<JSON>(
+      ApiEndpoint.derivedPeriod,
+      queryParams: {
+        QueryParamConstant.id: id,
+        QueryParamConstant.domain: domain,
+        QueryParamConstant.lang: lang.value,
+      },
+    );
+
+    if (result.containsKey('status') && result['status'] == 'Error') {
+      throw ApiException(result['message']?.toString() ?? '');
+    }
+
+    final response = ApiResponseModel<DerivedPeriodModel?>.fromJson(result, (
+      json,
+    ) {
+      if (json == null) {
+        return null;
+      }
+
+      return DerivedPeriodModel.fromJson(json as JSON);
+    });
+
+    if (response.dataAvailability == DataAvailability.notAvailable) {
+      throw const DerivedPeriodNotAvailableException();
+    }
+
+    return response;
+  }
 
   @override
   Future<ApiResponseModel<List<DerivedPeriodModel>?>> get({

--- a/packages/stadata_flutter_sdk/lib/src/features/derived_periods/data/repositories/derived_period_repository_impl.dart
+++ b/packages/stadata_flutter_sdk/lib/src/features/derived_periods/data/repositories/derived_period_repository_impl.dart
@@ -11,6 +11,38 @@ class DerivedPeriodRepositoryImpl implements DerivedPeriodRepository {
   final Log _log = injector.get<Log>();
 
   @override
+  Future<Result<Failure, ApiResponse<DerivedPeriod>>> detail({
+    required int id,
+    required String domain,
+    DataLanguage lang = DataLanguage.id,
+  }) async {
+    try {
+      final result = await _remoteDataSource.detail(
+        id: id,
+        lang: lang,
+        domain: domain,
+      );
+
+      if (result.data == null) {
+        throw const DerivedPeriodNotAvailableException();
+      }
+
+      return Result.success(
+        ApiResponse<DerivedPeriod>(
+          data: result.data,
+          status: result.status,
+          message: result.message,
+          pagination: result.pagination,
+          dataAvailability: result.dataAvailability,
+        ),
+      );
+    } catch (e, s) {
+      _log.console(e.toString(), error: e, stackTrace: s, type: LogType.error);
+      return Result.failure(DerivedPeriodFailure(message: e.toString()));
+    }
+  }
+
+  @override
   Future<Result<Failure, ApiResponse<List<DerivedPeriod>>>> get({
     required String domain,
     int page = 1,

--- a/packages/stadata_flutter_sdk/lib/src/features/derived_periods/domain/repositories/derived_period_repository.dart
+++ b/packages/stadata_flutter_sdk/lib/src/features/derived_periods/domain/repositories/derived_period_repository.dart
@@ -23,4 +23,9 @@ abstract class DerivedPeriodRepository {
     DataLanguage lang = DataLanguage.id,
     int? variableID,
   });
+  Future<Result<Failure, ApiResponse<DerivedPeriod>>> detail({
+    required int id,
+    required String domain,
+    DataLanguage lang = DataLanguage.id,
+  });
 }

--- a/packages/stadata_flutter_sdk/lib/src/features/derived_periods/domain/usecases/get_detail_derived_period.dart
+++ b/packages/stadata_flutter_sdk/lib/src/features/derived_periods/domain/usecases/get_detail_derived_period.dart
@@ -1,0 +1,34 @@
+import 'package:stadata_flutter_sdk/src/base/usecase.dart';
+import 'package:stadata_flutter_sdk/src/core/core.dart';
+import 'package:stadata_flutter_sdk/src/features/features.dart';
+import 'package:stadata_flutter_sdk/src/shared/shared.dart';
+
+class GetDetailDerivedPeriod
+    implements
+        UseCase<
+          ApiResponse<DerivedPeriod>,
+          GetDetailDerivedPeriodParam,
+          DerivedPeriodRepository
+        > {
+  @override
+  Future<Result<Failure, ApiResponse<DerivedPeriod>>> call(
+    GetDetailDerivedPeriodParam param,
+  ) => repo.detail(id: param.id, lang: param.lang, domain: param.domain);
+
+  @override
+  DerivedPeriodRepository get repo => injector.get<DerivedPeriodRepository>();
+}
+
+class GetDetailDerivedPeriodParam extends BaseEntity {
+  const GetDetailDerivedPeriodParam({
+    required this.id,
+    required this.domain,
+    this.lang = DataLanguage.id,
+  });
+  final int id;
+  final String domain;
+  final DataLanguage lang;
+
+  @override
+  List<Object> get props => [id, domain, lang];
+}

--- a/packages/stadata_flutter_sdk/lib/src/features/derived_periods/domain/usecases/usecases.dart
+++ b/packages/stadata_flutter_sdk/lib/src/features/derived_periods/domain/usecases/usecases.dart
@@ -1,1 +1,2 @@
 export 'get_all_derived_periods.dart';
+export 'get_detail_derived_period.dart';

--- a/packages/stadata_flutter_sdk/lib/src/features/derived_periods/injector/derived_period_injector.dart
+++ b/packages/stadata_flutter_sdk/lib/src/features/derived_periods/injector/derived_period_injector.dart
@@ -16,7 +16,9 @@ class DerivedPeriodInjector implements ModuleInjector {
       );
 
   @override
-  void injectUseCases(Injector injector) =>
-      injector
-        ..registerLazySingleton<GetAllDerivedPeriods>(GetAllDerivedPeriods.new);
+  void injectUseCases(Injector injector) => injector
+    ..registerLazySingleton<GetAllDerivedPeriods>(GetAllDerivedPeriods.new)
+    ..registerLazySingleton<GetDetailDerivedPeriod>(
+      GetDetailDerivedPeriod.new,
+    );
 }

--- a/packages/stadata_flutter_sdk/lib/src/features/derived_variables/data/datasources/derived_variable_remote_data_source.dart
+++ b/packages/stadata_flutter_sdk/lib/src/features/derived_variables/data/datasources/derived_variable_remote_data_source.dart
@@ -12,6 +12,11 @@ abstract class DerivedVariableRemoteDataSource {
     int? variableID,
     int? verticalGroup,
   });
+  Future<ApiResponseModel<DerivedVariableModel?>> detail({
+    required int id,
+    required String domain,
+    DataLanguage lang = DataLanguage.id,
+  });
 }
 
 /// Implementation of [DerivedVariableRemoteDataSource] that fetches data from BPS API.
@@ -20,6 +25,45 @@ class DerivedVariableRemoteDataSourceImpl
   final NetworkClient _listHttpModule = injector.get<NetworkClient>(
     instanceName: InjectorConstant.listClient,
   );
+  final NetworkClient _detailClient = injector.get<NetworkClient>(
+    instanceName: InjectorConstant.viewClient,
+  );
+
+  @override
+  Future<ApiResponseModel<DerivedVariableModel?>> detail({
+    required int id,
+    required String domain,
+    DataLanguage lang = DataLanguage.id,
+  }) async {
+    final result = await _detailClient.get<JSON>(
+      ApiEndpoint.derivedVariable,
+      queryParams: {
+        QueryParamConstant.id: id,
+        QueryParamConstant.domain: domain,
+        QueryParamConstant.lang: lang.value,
+      },
+    );
+
+    if (result.containsKey('status') && result['status'] == 'Error') {
+      throw ApiException(result['message']?.toString() ?? '');
+    }
+
+    final response = ApiResponseModel<DerivedVariableModel?>.fromJson(result, (
+      json,
+    ) {
+      if (json == null) {
+        return null;
+      }
+
+      return DerivedVariableModel.fromJson(json as JSON);
+    });
+
+    if (response.dataAvailability == DataAvailability.notAvailable) {
+      throw const DerivedVariableNotAvailableException();
+    }
+
+    return response;
+  }
 
   @override
   Future<ApiResponseModel<List<DerivedVariableModel>?>> get({

--- a/packages/stadata_flutter_sdk/lib/src/features/derived_variables/data/repositories/derived_variable_repository_impl.dart
+++ b/packages/stadata_flutter_sdk/lib/src/features/derived_variables/data/repositories/derived_variable_repository_impl.dart
@@ -11,6 +11,38 @@ class DerivedVariableRepositoryImpl implements DerivedVariableRepository {
   final Log _log = injector.get<Log>();
 
   @override
+  Future<Result<Failure, ApiResponse<DerivedVariable>>> detail({
+    required int id,
+    required String domain,
+    DataLanguage lang = DataLanguage.id,
+  }) async {
+    try {
+      final result = await _remoteDataSource.detail(
+        id: id,
+        lang: lang,
+        domain: domain,
+      );
+
+      if (result.data == null) {
+        throw const DerivedVariableNotAvailableException();
+      }
+
+      return Result.success(
+        ApiResponse<DerivedVariable>(
+          data: result.data,
+          status: result.status,
+          message: result.message,
+          pagination: result.pagination,
+          dataAvailability: result.dataAvailability,
+        ),
+      );
+    } catch (e, s) {
+      _log.console(e.toString(), error: e, stackTrace: s, type: LogType.error);
+      return Result.failure(DerivedVariableFailure(message: e.toString()));
+    }
+  }
+
+  @override
   Future<Result<Failure, ApiResponse<List<DerivedVariable>>>> get({
     required String domain,
     int page = 1,

--- a/packages/stadata_flutter_sdk/lib/src/features/derived_variables/domain/repositories/derived_variable_repository.dart
+++ b/packages/stadata_flutter_sdk/lib/src/features/derived_variables/domain/repositories/derived_variable_repository.dart
@@ -25,4 +25,9 @@ abstract class DerivedVariableRepository {
     int? variableID,
     int? verticalGroup,
   });
+  Future<Result<Failure, ApiResponse<DerivedVariable>>> detail({
+    required int id,
+    required String domain,
+    DataLanguage lang = DataLanguage.id,
+  });
 }

--- a/packages/stadata_flutter_sdk/lib/src/features/derived_variables/domain/usecases/get_detail_derived_variable.dart
+++ b/packages/stadata_flutter_sdk/lib/src/features/derived_variables/domain/usecases/get_detail_derived_variable.dart
@@ -1,0 +1,35 @@
+import 'package:stadata_flutter_sdk/src/base/usecase.dart';
+import 'package:stadata_flutter_sdk/src/core/core.dart';
+import 'package:stadata_flutter_sdk/src/features/features.dart';
+import 'package:stadata_flutter_sdk/src/shared/shared.dart';
+
+class GetDetailDerivedVariable
+    implements
+        UseCase<
+          ApiResponse<DerivedVariable>,
+          GetDetailDerivedVariableParam,
+          DerivedVariableRepository
+        > {
+  @override
+  Future<Result<Failure, ApiResponse<DerivedVariable>>> call(
+    GetDetailDerivedVariableParam param,
+  ) => repo.detail(id: param.id, lang: param.lang, domain: param.domain);
+
+  @override
+  DerivedVariableRepository get repo =>
+      injector.get<DerivedVariableRepository>();
+}
+
+class GetDetailDerivedVariableParam extends BaseEntity {
+  const GetDetailDerivedVariableParam({
+    required this.id,
+    required this.domain,
+    this.lang = DataLanguage.id,
+  });
+  final int id;
+  final String domain;
+  final DataLanguage lang;
+
+  @override
+  List<Object> get props => [id, domain, lang];
+}

--- a/packages/stadata_flutter_sdk/lib/src/features/derived_variables/domain/usecases/usecases.dart
+++ b/packages/stadata_flutter_sdk/lib/src/features/derived_variables/domain/usecases/usecases.dart
@@ -1,1 +1,2 @@
 export 'get_all_derived_variables.dart';
+export 'get_detail_derived_variable.dart';

--- a/packages/stadata_flutter_sdk/lib/src/features/derived_variables/injector/derived_variable_injector.dart
+++ b/packages/stadata_flutter_sdk/lib/src/features/derived_variables/injector/derived_variable_injector.dart
@@ -16,8 +16,9 @@ class DerivedVariableInjector implements ModuleInjector {
       );
 
   @override
-  void injectUseCases(Injector injector) =>
-      injector..registerLazySingleton<GetAllDerivedVariables>(
-        GetAllDerivedVariables.new,
-      );
+  void injectUseCases(Injector injector) => injector
+    ..registerLazySingleton<GetAllDerivedVariables>(GetAllDerivedVariables.new)
+    ..registerLazySingleton<GetDetailDerivedVariable>(
+      GetDetailDerivedVariable.new,
+    );
 }

--- a/packages/stadata_flutter_sdk/lib/src/features/infographics/data/datasources/infographic_remote_data_source.dart
+++ b/packages/stadata_flutter_sdk/lib/src/features/infographics/data/datasources/infographic_remote_data_source.dart
@@ -9,12 +9,56 @@ abstract class InfographicRemoteDataSource {
     int page = 1,
     String? keyword,
   });
+  Future<ApiResponseModel<InfographicModel?>> detail({
+    required int id,
+    required String domain,
+    DataLanguage lang = DataLanguage.id,
+  });
 }
 
 class InfographicRemoteDataSourceImpl implements InfographicRemoteDataSource {
   final NetworkClient _client = injector.get<NetworkClient>(
     instanceName: InjectorConstant.listClient,
   );
+  final NetworkClient _detailClient = injector.get<NetworkClient>(
+    instanceName: InjectorConstant.viewClient,
+  );
+
+  @override
+  Future<ApiResponseModel<InfographicModel?>> detail({
+    required int id,
+    required String domain,
+    DataLanguage lang = DataLanguage.id,
+  }) async {
+    final result = await _detailClient.get<JSON>(
+      ApiEndpoint.infographic,
+      queryParams: {
+        QueryParamConstant.id: id,
+        QueryParamConstant.domain: domain,
+        QueryParamConstant.lang: lang.value,
+      },
+    );
+
+    if (result.containsKey('status') && result['status'] == 'Error') {
+      throw ApiException(result['message']?.toString() ?? '');
+    }
+
+    final response = ApiResponseModel<InfographicModel?>.fromJson(result, (
+      json,
+    ) {
+      if (json == null) {
+        return null;
+      }
+
+      return InfographicModel.fromJson(json as JSON);
+    });
+
+    if (response.dataAvailability == DataAvailability.notAvailable) {
+      throw const InfographicNotAvailableException();
+    }
+
+    return response;
+  }
 
   @override
   Future<ApiResponseModel<List<InfographicModel>?>> get({

--- a/packages/stadata_flutter_sdk/lib/src/features/infographics/data/repositories/infographic_repository_impl.dart
+++ b/packages/stadata_flutter_sdk/lib/src/features/infographics/data/repositories/infographic_repository_impl.dart
@@ -10,6 +10,43 @@ class InfographicRepositoryImpl implements InfographicRepository {
   final Log _logger = injector.get<Log>();
 
   @override
+  Future<Result<Failure, ApiResponse<Infographic>>> detail({
+    required int id,
+    required String domain,
+    DataLanguage lang = DataLanguage.id,
+  }) async {
+    try {
+      final result = await _remoteDataSource.detail(
+        id: id,
+        lang: lang,
+        domain: domain,
+      );
+
+      if (result.data == null) {
+        throw const InfographicNotAvailableException();
+      }
+
+      return Result.success(
+        ApiResponse<Infographic>(
+          data: result.data,
+          status: result.status,
+          message: result.message,
+          pagination: result.pagination,
+          dataAvailability: result.dataAvailability,
+        ),
+      );
+    } catch (e, s) {
+      _logger.console(
+        e.toString(),
+        error: e,
+        stackTrace: s,
+        type: LogType.error,
+      );
+      return Result.failure(InfographicFailure(message: e.toString()));
+    }
+  }
+
+  @override
   Future<Result<Failure, ApiResponse<List<Infographic>>>> get({
     required String domain,
     DataLanguage lang = DataLanguage.id,

--- a/packages/stadata_flutter_sdk/lib/src/features/infographics/domain/repositories/infographic_repository.dart
+++ b/packages/stadata_flutter_sdk/lib/src/features/infographics/domain/repositories/infographic_repository.dart
@@ -9,4 +9,9 @@ abstract class InfographicRepository {
     int page = 1,
     String? keyword,
   });
+  Future<Result<Failure, ApiResponse<Infographic>>> detail({
+    required int id,
+    required String domain,
+    DataLanguage lang = DataLanguage.id,
+  });
 }

--- a/packages/stadata_flutter_sdk/lib/src/features/infographics/domain/usecases/get_detail_infographic.dart
+++ b/packages/stadata_flutter_sdk/lib/src/features/infographics/domain/usecases/get_detail_infographic.dart
@@ -1,0 +1,34 @@
+import 'package:stadata_flutter_sdk/src/base/usecase.dart';
+import 'package:stadata_flutter_sdk/src/core/core.dart';
+import 'package:stadata_flutter_sdk/src/features/features.dart';
+import 'package:stadata_flutter_sdk/src/shared/shared.dart';
+
+class GetDetailInfographic
+    implements
+        UseCase<
+          ApiResponse<Infographic>,
+          GetDetailInfographicParam,
+          InfographicRepository
+        > {
+  @override
+  Future<Result<Failure, ApiResponse<Infographic>>> call(
+    GetDetailInfographicParam param,
+  ) => repo.detail(id: param.id, lang: param.lang, domain: param.domain);
+
+  @override
+  InfographicRepository get repo => injector.get<InfographicRepository>();
+}
+
+class GetDetailInfographicParam extends BaseEntity {
+  const GetDetailInfographicParam({
+    required this.id,
+    required this.domain,
+    this.lang = DataLanguage.id,
+  });
+  final int id;
+  final String domain;
+  final DataLanguage lang;
+
+  @override
+  List<Object> get props => [id, domain, lang];
+}

--- a/packages/stadata_flutter_sdk/lib/src/features/infographics/domain/usecases/usecases.dart
+++ b/packages/stadata_flutter_sdk/lib/src/features/infographics/domain/usecases/usecases.dart
@@ -1,1 +1,2 @@
 export 'get_all_infographics.dart';
+export 'get_detail_infographic.dart';

--- a/packages/stadata_flutter_sdk/lib/src/features/infographics/injector/infographic_injector.dart
+++ b/packages/stadata_flutter_sdk/lib/src/features/infographics/injector/infographic_injector.dart
@@ -16,7 +16,7 @@ class InfographicInjector implements ModuleInjector {
       );
 
   @override
-  void injectUseCases(Injector injector) =>
-      injector
-        ..registerLazySingleton<GetAllInfographics>(GetAllInfographics.new);
+  void injectUseCases(Injector injector) => injector
+    ..registerLazySingleton<GetAllInfographics>(GetAllInfographics.new)
+    ..registerLazySingleton<GetDetailInfographic>(GetDetailInfographic.new);
 }

--- a/packages/stadata_flutter_sdk/lib/src/features/news_categories/data/datasources/news_category_remote_data_source.dart
+++ b/packages/stadata_flutter_sdk/lib/src/features/news_categories/data/datasources/news_category_remote_data_source.dart
@@ -7,12 +7,56 @@ abstract class NewsCategoryRemoteDataSource {
     required String domain,
     DataLanguage lang = DataLanguage.id,
   });
+  Future<ApiResponseModel<NewsCategoryModel?>> detail({
+    required String id,
+    required String domain,
+    DataLanguage lang = DataLanguage.id,
+  });
 }
 
 class NewsCategoryRemoteDataSourceImpl implements NewsCategoryRemoteDataSource {
   final NetworkClient _listClient = injector.get<NetworkClient>(
     instanceName: InjectorConstant.listClient,
   );
+  final NetworkClient _detailClient = injector.get<NetworkClient>(
+    instanceName: InjectorConstant.viewClient,
+  );
+
+  @override
+  Future<ApiResponseModel<NewsCategoryModel?>> detail({
+    required String id,
+    required String domain,
+    DataLanguage lang = DataLanguage.id,
+  }) async {
+    final result = await _detailClient.get<JSON>(
+      ApiEndpoint.newsCategory,
+      queryParams: {
+        QueryParamConstant.id: id,
+        QueryParamConstant.domain: domain,
+        QueryParamConstant.lang: lang.value,
+      },
+    );
+
+    if (result.containsKey('status') && result['status'] == 'Error') {
+      throw ApiException(result['message']?.toString() ?? '');
+    }
+
+    final response = ApiResponseModel<NewsCategoryModel?>.fromJson(result, (
+      json,
+    ) {
+      if (json == null) {
+        return null;
+      }
+
+      return NewsCategoryModel.fromJson(json as JSON);
+    });
+
+    if (response.dataAvailability == DataAvailability.notAvailable) {
+      throw const NewsCategoryNotAvailableException();
+    }
+
+    return response;
+  }
 
   @override
   Future<ApiResponseModel<List<NewsCategoryModel>?>> get({

--- a/packages/stadata_flutter_sdk/lib/src/features/news_categories/data/repositories/news_category_repository_impl.dart
+++ b/packages/stadata_flutter_sdk/lib/src/features/news_categories/data/repositories/news_category_repository_impl.dart
@@ -10,6 +10,38 @@ class NewsCategoryRepositoryImpl implements NewsCategoryRepository {
   final Log _log = injector.get<Log>();
 
   @override
+  Future<Result<Failure, ApiResponse<NewsCategory>>> detail({
+    required String id,
+    required String domain,
+    DataLanguage lang = DataLanguage.id,
+  }) async {
+    try {
+      final result = await _dataSource.detail(
+        id: id,
+        lang: lang,
+        domain: domain,
+      );
+
+      if (result.data == null) {
+        throw const NewsCategoryNotAvailableException();
+      }
+
+      return Result.success(
+        ApiResponse<NewsCategory>(
+          data: result.data,
+          status: result.status,
+          message: result.message,
+          pagination: result.pagination,
+          dataAvailability: result.dataAvailability,
+        ),
+      );
+    } catch (e, s) {
+      _log.console(e.toString(), error: e, stackTrace: s, type: LogType.error);
+      return Result.failure(NewsCategoryFailure(message: e.toString()));
+    }
+  }
+
+  @override
   Future<Result<Failure, ApiResponse<List<NewsCategory>>>> get({
     required String domain,
     DataLanguage lang = DataLanguage.id,

--- a/packages/stadata_flutter_sdk/lib/src/features/news_categories/domain/repositories/news_category_repository.dart
+++ b/packages/stadata_flutter_sdk/lib/src/features/news_categories/domain/repositories/news_category_repository.dart
@@ -7,4 +7,9 @@ abstract class NewsCategoryRepository {
     required String domain,
     DataLanguage lang = DataLanguage.id,
   });
+  Future<Result<Failure, ApiResponse<NewsCategory>>> detail({
+    required String id,
+    required String domain,
+    DataLanguage lang = DataLanguage.id,
+  });
 }

--- a/packages/stadata_flutter_sdk/lib/src/features/news_categories/domain/usecases/get_detail_news_category.dart
+++ b/packages/stadata_flutter_sdk/lib/src/features/news_categories/domain/usecases/get_detail_news_category.dart
@@ -1,0 +1,34 @@
+import 'package:stadata_flutter_sdk/src/base/usecase.dart';
+import 'package:stadata_flutter_sdk/src/core/core.dart';
+import 'package:stadata_flutter_sdk/src/features/features.dart';
+import 'package:stadata_flutter_sdk/src/shared/shared.dart';
+
+class GetDetailNewsCategory
+    implements
+        UseCase<
+          ApiResponse<NewsCategory>,
+          GetDetailNewsCategoryParam,
+          NewsCategoryRepository
+        > {
+  @override
+  Future<Result<Failure, ApiResponse<NewsCategory>>> call(
+    GetDetailNewsCategoryParam param,
+  ) => repo.detail(id: param.id, lang: param.lang, domain: param.domain);
+
+  @override
+  NewsCategoryRepository get repo => injector.get<NewsCategoryRepository>();
+}
+
+class GetDetailNewsCategoryParam extends BaseEntity {
+  const GetDetailNewsCategoryParam({
+    required this.id,
+    required this.domain,
+    this.lang = DataLanguage.id,
+  });
+  final String id;
+  final String domain;
+  final DataLanguage lang;
+
+  @override
+  List<Object> get props => [id, domain, lang];
+}

--- a/packages/stadata_flutter_sdk/lib/src/features/news_categories/domain/usecases/usecases.dart
+++ b/packages/stadata_flutter_sdk/lib/src/features/news_categories/domain/usecases/usecases.dart
@@ -1,1 +1,2 @@
 export 'get_all_news_categories.dart';
+export 'get_detail_news_category.dart';

--- a/packages/stadata_flutter_sdk/lib/src/features/news_categories/injector/news_category_injector.dart
+++ b/packages/stadata_flutter_sdk/lib/src/features/news_categories/injector/news_category_injector.dart
@@ -16,7 +16,9 @@ class NewsCategoryInjector implements ModuleInjector {
       );
 
   @override
-  void injectUseCases(Injector injector) =>
-      injector
-        ..registerLazySingleton<GetAllNewsCategories>(GetAllNewsCategories.new);
+  void injectUseCases(Injector injector) => injector
+    ..registerLazySingleton<GetAllNewsCategories>(GetAllNewsCategories.new)
+    ..registerLazySingleton<GetDetailNewsCategory>(
+      GetDetailNewsCategory.new,
+    );
 }

--- a/packages/stadata_flutter_sdk/lib/src/features/periods/data/datasources/period_remote_data_source.dart
+++ b/packages/stadata_flutter_sdk/lib/src/features/periods/data/datasources/period_remote_data_source.dart
@@ -17,6 +17,11 @@ abstract class PeriodRemoteDataSource {
     DataLanguage lang = DataLanguage.id,
     int? variableID,
   });
+  Future<ApiResponseModel<PeriodModel?>> detail({
+    required int id,
+    required String domain,
+    DataLanguage lang = DataLanguage.id,
+  });
 }
 
 /// Implementation of [PeriodRemoteDataSource] that fetches data from BPS API.
@@ -24,6 +29,43 @@ class PeriodRemoteDataSourceImpl implements PeriodRemoteDataSource {
   final NetworkClient _listHttpModule = injector.get<NetworkClient>(
     instanceName: InjectorConstant.listClient,
   );
+  final NetworkClient _detailClient = injector.get<NetworkClient>(
+    instanceName: InjectorConstant.viewClient,
+  );
+
+  @override
+  Future<ApiResponseModel<PeriodModel?>> detail({
+    required int id,
+    required String domain,
+    DataLanguage lang = DataLanguage.id,
+  }) async {
+    final result = await _detailClient.get<JSON>(
+      ApiEndpoint.period,
+      queryParams: {
+        QueryParamConstant.id: id,
+        QueryParamConstant.domain: domain,
+        QueryParamConstant.lang: lang.value,
+      },
+    );
+
+    if (result.containsKey('status') && result['status'] == 'Error') {
+      throw ApiException(result['message']?.toString() ?? '');
+    }
+
+    final response = ApiResponseModel<PeriodModel?>.fromJson(result, (json) {
+      if (json == null) {
+        return null;
+      }
+
+      return PeriodModel.fromJson(json as JSON);
+    });
+
+    if (response.dataAvailability == DataAvailability.notAvailable) {
+      throw const PeriodNotAvailableException();
+    }
+
+    return response;
+  }
 
   @override
   Future<ApiResponseModel<List<PeriodModel>?>> get({

--- a/packages/stadata_flutter_sdk/lib/src/features/periods/data/repositories/period_repository_impl.dart
+++ b/packages/stadata_flutter_sdk/lib/src/features/periods/data/repositories/period_repository_impl.dart
@@ -14,6 +14,38 @@ class PeriodRepositoryImpl implements PeriodRepository {
   final Log _log = injector.get<Log>();
 
   @override
+  Future<Result<Failure, ApiResponse<Period>>> detail({
+    required int id,
+    required String domain,
+    DataLanguage lang = DataLanguage.id,
+  }) async {
+    try {
+      final result = await _remoteDataSource.detail(
+        id: id,
+        lang: lang,
+        domain: domain,
+      );
+
+      if (result.data == null) {
+        throw const PeriodNotAvailableException();
+      }
+
+      return Result.success(
+        ApiResponse<Period>(
+          data: result.data,
+          status: result.status,
+          message: result.message,
+          pagination: result.pagination,
+          dataAvailability: result.dataAvailability,
+        ),
+      );
+    } catch (e, s) {
+      _log.console(e.toString(), error: e, stackTrace: s, type: LogType.error);
+      return Result.failure(PeriodFailure(message: e.toString()));
+    }
+  }
+
+  @override
   Future<Result<Failure, ApiResponse<List<Period>>>> get({
     required String domain,
     int page = 1,

--- a/packages/stadata_flutter_sdk/lib/src/features/periods/domain/repositories/period_repository.dart
+++ b/packages/stadata_flutter_sdk/lib/src/features/periods/domain/repositories/period_repository.dart
@@ -25,4 +25,9 @@ abstract class PeriodRepository {
     DataLanguage lang = DataLanguage.id,
     int? variableID,
   });
+  Future<Result<Failure, ApiResponse<Period>>> detail({
+    required int id,
+    required String domain,
+    DataLanguage lang = DataLanguage.id,
+  });
 }

--- a/packages/stadata_flutter_sdk/lib/src/features/periods/domain/usecases/get_detail_period.dart
+++ b/packages/stadata_flutter_sdk/lib/src/features/periods/domain/usecases/get_detail_period.dart
@@ -1,0 +1,30 @@
+import 'package:stadata_flutter_sdk/src/base/usecase.dart';
+import 'package:stadata_flutter_sdk/src/core/core.dart';
+import 'package:stadata_flutter_sdk/src/features/features.dart';
+import 'package:stadata_flutter_sdk/src/shared/shared.dart';
+
+class GetDetailPeriod
+    implements
+        UseCase<ApiResponse<Period>, GetDetailPeriodParam, PeriodRepository> {
+  @override
+  Future<Result<Failure, ApiResponse<Period>>> call(
+    GetDetailPeriodParam param,
+  ) => repo.detail(id: param.id, lang: param.lang, domain: param.domain);
+
+  @override
+  PeriodRepository get repo => injector.get<PeriodRepository>();
+}
+
+class GetDetailPeriodParam extends BaseEntity {
+  const GetDetailPeriodParam({
+    required this.id,
+    required this.domain,
+    this.lang = DataLanguage.id,
+  });
+  final int id;
+  final String domain;
+  final DataLanguage lang;
+
+  @override
+  List<Object> get props => [id, domain, lang];
+}

--- a/packages/stadata_flutter_sdk/lib/src/features/periods/domain/usecases/usecases.dart
+++ b/packages/stadata_flutter_sdk/lib/src/features/periods/domain/usecases/usecases.dart
@@ -1,1 +1,2 @@
 export 'get_all_periods.dart';
+export 'get_detail_period.dart';

--- a/packages/stadata_flutter_sdk/lib/src/features/periods/injector/period_injector.dart
+++ b/packages/stadata_flutter_sdk/lib/src/features/periods/injector/period_injector.dart
@@ -18,6 +18,7 @@ class PeriodInjector implements ModuleInjector {
         ..registerLazySingleton<PeriodRepository>(PeriodRepositoryImpl.new);
 
   @override
-  void injectUseCases(Injector injector) =>
-      injector..registerLazySingleton<GetAllPeriods>(GetAllPeriods.new);
+  void injectUseCases(Injector injector) => injector
+    ..registerLazySingleton<GetAllPeriods>(GetAllPeriods.new)
+    ..registerLazySingleton<GetDetailPeriod>(GetDetailPeriod.new);
 }

--- a/packages/stadata_flutter_sdk/lib/src/features/strategic_indicators/data/datasources/strategic_indicator_remote_data_source.dart
+++ b/packages/stadata_flutter_sdk/lib/src/features/strategic_indicators/data/datasources/strategic_indicator_remote_data_source.dart
@@ -9,6 +9,11 @@ abstract interface class StrategicIndicatorRemoteDataSource {
     int page = 1,
     int? variableID,
   });
+  Future<ApiResponseModel<StrategicIndicatorModel?>> detail({
+    required int id,
+    required String domain,
+    DataLanguage lang = DataLanguage.id,
+  });
 }
 
 class StrategicIndicatorRemoteDataSourceImpl
@@ -16,6 +21,46 @@ class StrategicIndicatorRemoteDataSourceImpl
   final NetworkClient _listClient = injector.get<NetworkClient>(
     instanceName: InjectorConstant.listClient,
   );
+  final NetworkClient _detailClient = injector.get<NetworkClient>(
+    instanceName: InjectorConstant.viewClient,
+  );
+
+  @override
+  Future<ApiResponseModel<StrategicIndicatorModel?>> detail({
+    required int id,
+    required String domain,
+    DataLanguage lang = DataLanguage.id,
+  }) async {
+    final result = await _detailClient.get<JSON>(
+      ApiEndpoint.strategicIndicator,
+      queryParams: {
+        QueryParamConstant.id: id,
+        QueryParamConstant.domain: domain,
+        QueryParamConstant.lang: lang.value,
+      },
+    );
+
+    if (result.containsKey('status') && result['status'] == 'Error') {
+      throw ApiException(result['message']?.toString() ?? '');
+    }
+
+    final response = ApiResponseModel<StrategicIndicatorModel?>.fromJson(
+      result,
+      (json) {
+        if (json == null) {
+          return null;
+        }
+
+        return StrategicIndicatorModel.fromJson(json as JSON);
+      },
+    );
+
+    if (response.dataAvailability == DataAvailability.notAvailable) {
+      throw const StrategicIndicatorNotAvailableException();
+    }
+
+    return response;
+  }
 
   @override
   Future<ApiResponseModel<List<StrategicIndicatorModel>?>> get({

--- a/packages/stadata_flutter_sdk/lib/src/features/strategic_indicators/data/repositories/strategic_indicator_repository_impl.dart
+++ b/packages/stadata_flutter_sdk/lib/src/features/strategic_indicators/data/repositories/strategic_indicator_repository_impl.dart
@@ -10,6 +10,38 @@ class StrategicIndicatorRepositoryImpl implements StrategicIndicatorRepository {
   final Log _log = injector.get<Log>();
 
   @override
+  Future<Result<Failure, ApiResponse<StrategicIndicator>>> detail({
+    required int id,
+    required String domain,
+    DataLanguage lang = DataLanguage.id,
+  }) async {
+    try {
+      final result = await _dataSource.detail(
+        id: id,
+        lang: lang,
+        domain: domain,
+      );
+
+      if (result.data == null) {
+        throw const StrategicIndicatorNotAvailableException();
+      }
+
+      return Result.success(
+        ApiResponse<StrategicIndicator>(
+          data: result.data,
+          status: result.status,
+          message: result.message,
+          pagination: result.pagination,
+          dataAvailability: result.dataAvailability,
+        ),
+      );
+    } catch (e, s) {
+      _log.console(e.toString(), error: e, stackTrace: s, type: LogType.error);
+      return Result.failure(StrategicIndicatorFailure(message: e.toString()));
+    }
+  }
+
+  @override
   Future<Result<Failure, ApiResponse<List<StrategicIndicator>>>> get({
     required String domain,
     DataLanguage lang = DataLanguage.id,

--- a/packages/stadata_flutter_sdk/lib/src/features/strategic_indicators/domain/repositories/strategic_indicator_repository.dart
+++ b/packages/stadata_flutter_sdk/lib/src/features/strategic_indicators/domain/repositories/strategic_indicator_repository.dart
@@ -9,4 +9,9 @@ abstract interface class StrategicIndicatorRepository {
     int? variableID,
     int page = 1,
   });
+  Future<Result<Failure, ApiResponse<StrategicIndicator>>> detail({
+    required int id,
+    required String domain,
+    DataLanguage lang = DataLanguage.id,
+  });
 }

--- a/packages/stadata_flutter_sdk/lib/src/features/strategic_indicators/domain/usecases/get_detail_strategic_indicator.dart
+++ b/packages/stadata_flutter_sdk/lib/src/features/strategic_indicators/domain/usecases/get_detail_strategic_indicator.dart
@@ -1,0 +1,35 @@
+import 'package:stadata_flutter_sdk/src/base/usecase.dart';
+import 'package:stadata_flutter_sdk/src/core/core.dart';
+import 'package:stadata_flutter_sdk/src/features/features.dart';
+import 'package:stadata_flutter_sdk/src/shared/shared.dart';
+
+class GetDetailStrategicIndicator
+    implements
+        UseCase<
+          ApiResponse<StrategicIndicator>,
+          GetDetailStrategicIndicatorParam,
+          StrategicIndicatorRepository
+        > {
+  @override
+  Future<Result<Failure, ApiResponse<StrategicIndicator>>> call(
+    GetDetailStrategicIndicatorParam param,
+  ) => repo.detail(id: param.id, lang: param.lang, domain: param.domain);
+
+  @override
+  StrategicIndicatorRepository get repo =>
+      injector.get<StrategicIndicatorRepository>();
+}
+
+class GetDetailStrategicIndicatorParam extends BaseEntity {
+  const GetDetailStrategicIndicatorParam({
+    required this.id,
+    required this.domain,
+    this.lang = DataLanguage.id,
+  });
+  final int id;
+  final String domain;
+  final DataLanguage lang;
+
+  @override
+  List<Object> get props => [id, domain, lang];
+}

--- a/packages/stadata_flutter_sdk/lib/src/features/strategic_indicators/domain/usecases/usecases.dart
+++ b/packages/stadata_flutter_sdk/lib/src/features/strategic_indicators/domain/usecases/usecases.dart
@@ -1,1 +1,2 @@
 export 'get_all_strategic_indicators.dart';
+export 'get_detail_strategic_indicator.dart';

--- a/packages/stadata_flutter_sdk/lib/src/features/strategic_indicators/injector/strategic_indicator_injector.dart
+++ b/packages/stadata_flutter_sdk/lib/src/features/strategic_indicators/injector/strategic_indicator_injector.dart
@@ -17,8 +17,11 @@ class StrategicIndicatorInjector implements ModuleInjector {
       );
 
   @override
-  void injectUseCases(Injector injector) =>
-      injector..registerLazySingleton<GetAllStrategicIndicators>(
-        GetAllStrategicIndicators.new,
-      );
+  void injectUseCases(Injector injector) => injector
+    ..registerLazySingleton<GetAllStrategicIndicators>(
+      GetAllStrategicIndicators.new,
+    )
+    ..registerLazySingleton<GetDetailStrategicIndicator>(
+      GetDetailStrategicIndicator.new,
+    );
 }

--- a/packages/stadata_flutter_sdk/lib/src/features/subject_categories/data/datasources/subject_category_remote_data_source.dart
+++ b/packages/stadata_flutter_sdk/lib/src/features/subject_categories/data/datasources/subject_category_remote_data_source.dart
@@ -8,6 +8,11 @@ abstract class SubjectCategoryRemoteDataSource {
     DataLanguage lang = DataLanguage.id,
     int page = 1,
   });
+  Future<ApiResponseModel<SubjectCategoryModel?>> detail({
+    required int id,
+    required String domain,
+    DataLanguage lang = DataLanguage.id,
+  });
 }
 
 class SubjectCategoryRemoteDataSourceImpl
@@ -15,6 +20,46 @@ class SubjectCategoryRemoteDataSourceImpl
   final NetworkClient _listHttpModule = injector.get<NetworkClient>(
     instanceName: InjectorConstant.listClient,
   );
+  final NetworkClient _detailClient = injector.get<NetworkClient>(
+    instanceName: InjectorConstant.viewClient,
+  );
+
+  @override
+  Future<ApiResponseModel<SubjectCategoryModel?>> detail({
+    required int id,
+    required String domain,
+    DataLanguage lang = DataLanguage.id,
+  }) async {
+    final result = await _detailClient.get<JSON>(
+      ApiEndpoint.subjectCategory,
+      queryParams: {
+        QueryParamConstant.id: id,
+        QueryParamConstant.domain: domain,
+        QueryParamConstant.lang: lang.value,
+      },
+    );
+
+    if (result.containsKey('status') && result['status'] == 'Error') {
+      throw ApiException(result['message']?.toString() ?? '');
+    }
+
+    final response = ApiResponseModel<SubjectCategoryModel?>.fromJson(
+      result,
+      (json) {
+        if (json == null) {
+          return null;
+        }
+
+        return SubjectCategoryModel.fromJson(json as JSON);
+      },
+    );
+
+    if (response.dataAvailability == DataAvailability.notAvailable) {
+      throw const SubjectCategoryNotAvailableException();
+    }
+
+    return response;
+  }
 
   @override
   Future<ApiResponseModel<List<SubjectCategoryModel>?>> get({

--- a/packages/stadata_flutter_sdk/lib/src/features/subject_categories/data/repositories/subject_category_repository_impl.dart
+++ b/packages/stadata_flutter_sdk/lib/src/features/subject_categories/data/repositories/subject_category_repository_impl.dart
@@ -10,6 +10,38 @@ class SubjectCategoryRepositoryImpl implements SubjectCategoryRepository {
   final Log _log = injector.get<Log>();
 
   @override
+  Future<Result<Failure, ApiResponse<SubjectCategory>>> detail({
+    required int id,
+    required String domain,
+    DataLanguage lang = DataLanguage.id,
+  }) async {
+    try {
+      final result = await _remoteDataSource.detail(
+        id: id,
+        lang: lang,
+        domain: domain,
+      );
+
+      if (result.data == null) {
+        throw const SubjectCategoryNotAvailableException();
+      }
+
+      return Result.success(
+        ApiResponse<SubjectCategory>(
+          data: result.data,
+          status: result.status,
+          message: result.message,
+          pagination: result.pagination,
+          dataAvailability: result.dataAvailability,
+        ),
+      );
+    } catch (e, s) {
+      _log.console(e.toString(), error: e, stackTrace: s, type: LogType.error);
+      return Result.failure(SubjectCategoryFailure(message: e.toString()));
+    }
+  }
+
+  @override
   Future<Result<Failure, ApiResponse<List<SubjectCategory>>>> get({
     required String domain,
     DataLanguage lang = DataLanguage.id,

--- a/packages/stadata_flutter_sdk/lib/src/features/subject_categories/domain/repositories/subject_category_repository.dart
+++ b/packages/stadata_flutter_sdk/lib/src/features/subject_categories/domain/repositories/subject_category_repository.dart
@@ -8,4 +8,9 @@ abstract class SubjectCategoryRepository {
     DataLanguage lang = DataLanguage.id,
     int page = 1,
   });
+  Future<Result<Failure, ApiResponse<SubjectCategory>>> detail({
+    required int id,
+    required String domain,
+    DataLanguage lang = DataLanguage.id,
+  });
 }

--- a/packages/stadata_flutter_sdk/lib/src/features/subject_categories/domain/usecases/get_detail_subject_category.dart
+++ b/packages/stadata_flutter_sdk/lib/src/features/subject_categories/domain/usecases/get_detail_subject_category.dart
@@ -1,0 +1,35 @@
+import 'package:stadata_flutter_sdk/src/base/usecase.dart';
+import 'package:stadata_flutter_sdk/src/core/core.dart';
+import 'package:stadata_flutter_sdk/src/features/features.dart';
+import 'package:stadata_flutter_sdk/src/shared/shared.dart';
+
+class GetDetailSubjectCategory
+    implements
+        UseCase<
+          ApiResponse<SubjectCategory>,
+          GetDetailSubjectCategoryParam,
+          SubjectCategoryRepository
+        > {
+  @override
+  Future<Result<Failure, ApiResponse<SubjectCategory>>> call(
+    GetDetailSubjectCategoryParam param,
+  ) => repo.detail(id: param.id, lang: param.lang, domain: param.domain);
+
+  @override
+  SubjectCategoryRepository get repo =>
+      injector.get<SubjectCategoryRepository>();
+}
+
+class GetDetailSubjectCategoryParam extends BaseEntity {
+  const GetDetailSubjectCategoryParam({
+    required this.id,
+    required this.domain,
+    this.lang = DataLanguage.id,
+  });
+  final int id;
+  final String domain;
+  final DataLanguage lang;
+
+  @override
+  List<Object> get props => [id, domain, lang];
+}

--- a/packages/stadata_flutter_sdk/lib/src/features/subject_categories/domain/usecases/usecases.dart
+++ b/packages/stadata_flutter_sdk/lib/src/features/subject_categories/domain/usecases/usecases.dart
@@ -1,1 +1,2 @@
 export 'get_all_subject_categories.dart';
+export 'get_detail_subject_category.dart';

--- a/packages/stadata_flutter_sdk/lib/src/features/subject_categories/injector/subject_category_injector.dart
+++ b/packages/stadata_flutter_sdk/lib/src/features/subject_categories/injector/subject_category_injector.dart
@@ -16,8 +16,11 @@ class SubjectCategoryInjector implements ModuleInjector {
       );
 
   @override
-  void injectUseCases(Injector injector) =>
-      injector..registerLazySingleton<GetAllSubjectCategories>(
-        GetAllSubjectCategories.new,
-      );
+  void injectUseCases(Injector injector) => injector
+    ..registerLazySingleton<GetAllSubjectCategories>(
+      GetAllSubjectCategories.new,
+    )
+    ..registerLazySingleton<GetDetailSubjectCategory>(
+      GetDetailSubjectCategory.new,
+    );
 }

--- a/packages/stadata_flutter_sdk/lib/src/features/subjects/data/datasources/subject_remote_data_source.dart
+++ b/packages/stadata_flutter_sdk/lib/src/features/subjects/data/datasources/subject_remote_data_source.dart
@@ -9,12 +9,54 @@ abstract class SubjectRemoteDataSource {
     DataLanguage lang = DataLanguage.id,
     int page = 1,
   });
+  Future<ApiResponseModel<SubjectModel?>> detail({
+    required int id,
+    required String domain,
+    DataLanguage lang = DataLanguage.id,
+  });
 }
 
 class SubjectRemoteDataSourceImpl implements SubjectRemoteDataSource {
   final NetworkClient _listHttpModule = injector.get<NetworkClient>(
     instanceName: InjectorConstant.listClient,
   );
+  final NetworkClient _detailClient = injector.get<NetworkClient>(
+    instanceName: InjectorConstant.viewClient,
+  );
+
+  @override
+  Future<ApiResponseModel<SubjectModel?>> detail({
+    required int id,
+    required String domain,
+    DataLanguage lang = DataLanguage.id,
+  }) async {
+    final result = await _detailClient.get<JSON>(
+      ApiEndpoint.subject,
+      queryParams: {
+        QueryParamConstant.id: id,
+        QueryParamConstant.domain: domain,
+        QueryParamConstant.lang: lang.value,
+      },
+    );
+
+    if (result.containsKey('status') && result['status'] == 'Error') {
+      throw ApiException(result['message']?.toString() ?? '');
+    }
+
+    final response = ApiResponseModel<SubjectModel?>.fromJson(result, (json) {
+      if (json == null) {
+        return null;
+      }
+
+      return SubjectModel.fromJson(json as JSON);
+    });
+
+    if (response.dataAvailability == DataAvailability.notAvailable) {
+      throw const SubjectNotAvailableException();
+    }
+
+    return response;
+  }
 
   @override
   Future<ApiResponseModel<List<SubjectModel>?>> get({

--- a/packages/stadata_flutter_sdk/lib/src/features/subjects/data/repositories/subject_repository_impl.dart
+++ b/packages/stadata_flutter_sdk/lib/src/features/subjects/data/repositories/subject_repository_impl.dart
@@ -10,6 +10,38 @@ class SubjectRepositoryImpl implements SubjectRepository {
   final Log _log = injector.get<Log>();
 
   @override
+  Future<Result<Failure, ApiResponse<Subject>>> detail({
+    required int id,
+    required String domain,
+    DataLanguage lang = DataLanguage.id,
+  }) async {
+    try {
+      final result = await _remoteDataSource.detail(
+        id: id,
+        lang: lang,
+        domain: domain,
+      );
+
+      if (result.data == null) {
+        throw const SubjectNotAvailableException();
+      }
+
+      return Result.success(
+        ApiResponse<Subject>(
+          data: result.data,
+          status: result.status,
+          message: result.message,
+          pagination: result.pagination,
+          dataAvailability: result.dataAvailability,
+        ),
+      );
+    } catch (e, s) {
+      _log.console(e.toString(), error: e, stackTrace: s, type: LogType.error);
+      return Result.failure(SubjectFailure(message: e.toString()));
+    }
+  }
+
+  @override
   Future<Result<Failure, ApiResponse<List<Subject>>>> get({
     required String domain,
     int? subjectCategoryID,

--- a/packages/stadata_flutter_sdk/lib/src/features/subjects/domain/repositories/subject_repository.dart
+++ b/packages/stadata_flutter_sdk/lib/src/features/subjects/domain/repositories/subject_repository.dart
@@ -9,4 +9,9 @@ abstract class SubjectRepository {
     DataLanguage lang = DataLanguage.id,
     int page = 1,
   });
+  Future<Result<Failure, ApiResponse<Subject>>> detail({
+    required int id,
+    required String domain,
+    DataLanguage lang = DataLanguage.id,
+  });
 }

--- a/packages/stadata_flutter_sdk/lib/src/features/subjects/domain/usecases/get_detail_subject.dart
+++ b/packages/stadata_flutter_sdk/lib/src/features/subjects/domain/usecases/get_detail_subject.dart
@@ -1,0 +1,34 @@
+import 'package:stadata_flutter_sdk/src/base/usecase.dart';
+import 'package:stadata_flutter_sdk/src/core/core.dart';
+import 'package:stadata_flutter_sdk/src/features/features.dart';
+import 'package:stadata_flutter_sdk/src/shared/shared.dart';
+
+class GetDetailSubject
+    implements
+        UseCase<
+          ApiResponse<Subject>,
+          GetDetailSubjectParam,
+          SubjectRepository
+        > {
+  @override
+  Future<Result<Failure, ApiResponse<Subject>>> call(
+    GetDetailSubjectParam param,
+  ) => repo.detail(id: param.id, lang: param.lang, domain: param.domain);
+
+  @override
+  SubjectRepository get repo => injector.get<SubjectRepository>();
+}
+
+class GetDetailSubjectParam extends BaseEntity {
+  const GetDetailSubjectParam({
+    required this.id,
+    required this.domain,
+    this.lang = DataLanguage.id,
+  });
+  final int id;
+  final String domain;
+  final DataLanguage lang;
+
+  @override
+  List<Object> get props => [id, domain, lang];
+}

--- a/packages/stadata_flutter_sdk/lib/src/features/subjects/domain/usecases/usecases.dart
+++ b/packages/stadata_flutter_sdk/lib/src/features/subjects/domain/usecases/usecases.dart
@@ -1,1 +1,2 @@
 export 'get_all_subjects.dart';
+export 'get_detail_subject.dart';

--- a/packages/stadata_flutter_sdk/lib/src/features/subjects/injector/subject_injector.dart
+++ b/packages/stadata_flutter_sdk/lib/src/features/subjects/injector/subject_injector.dart
@@ -15,6 +15,7 @@ class SubjectInjector implements ModuleInjector {
         ..registerLazySingleton<SubjectRepository>(SubjectRepositoryImpl.new);
 
   @override
-  void injectUseCases(Injector injector) =>
-      injector..registerLazySingleton<GetAllSubjects>(GetAllSubjects.new);
+  void injectUseCases(Injector injector) => injector
+    ..registerLazySingleton<GetAllSubjects>(GetAllSubjects.new)
+    ..registerLazySingleton<GetDetailSubject>(GetDetailSubject.new);
 }

--- a/packages/stadata_flutter_sdk/lib/src/features/units/data/datasources/unit_data_remote_data_source.dart
+++ b/packages/stadata_flutter_sdk/lib/src/features/units/data/datasources/unit_data_remote_data_source.dart
@@ -9,12 +9,54 @@ abstract class UnitDataRemoteDataSource {
     int page = 1,
     int? variableID,
   });
+  Future<ApiResponseModel<UnitDataModel?>> detail({
+    required int id,
+    required String domain,
+    DataLanguage lang = DataLanguage.id,
+  });
 }
 
 class UnitDataRemoteDataSourceImpl implements UnitDataRemoteDataSource {
   final NetworkClient _listHttpModule = injector.get<NetworkClient>(
     instanceName: InjectorConstant.listClient,
   );
+  final NetworkClient _detailClient = injector.get<NetworkClient>(
+    instanceName: InjectorConstant.viewClient,
+  );
+
+  @override
+  Future<ApiResponseModel<UnitDataModel?>> detail({
+    required int id,
+    required String domain,
+    DataLanguage lang = DataLanguage.id,
+  }) async {
+    final result = await _detailClient.get<JSON>(
+      ApiEndpoint.unit,
+      queryParams: {
+        QueryParamConstant.id: id,
+        QueryParamConstant.domain: domain,
+        QueryParamConstant.lang: lang.value,
+      },
+    );
+
+    if (result.containsKey('status') && result['status'] == 'Error') {
+      throw ApiException(result['message']?.toString() ?? '');
+    }
+
+    final response = ApiResponseModel<UnitDataModel?>.fromJson(result, (json) {
+      if (json == null) {
+        return null;
+      }
+
+      return UnitDataModel.fromJson(json as JSON);
+    });
+
+    if (response.dataAvailability == DataAvailability.notAvailable) {
+      throw const UnitNotAvailableException();
+    }
+
+    return response;
+  }
 
   @override
   Future<ApiResponseModel<List<UnitDataModel>?>> get({

--- a/packages/stadata_flutter_sdk/lib/src/features/units/data/repositories/unit_data_repository_impl.dart
+++ b/packages/stadata_flutter_sdk/lib/src/features/units/data/repositories/unit_data_repository_impl.dart
@@ -10,6 +10,38 @@ class UnitDataRepositoryImpl implements UnitDataRepository {
   final Log _log = injector.get<Log>();
 
   @override
+  Future<Result<Failure, ApiResponse<UnitData>>> detail({
+    required int id,
+    required String domain,
+    DataLanguage lang = DataLanguage.id,
+  }) async {
+    try {
+      final result = await _remoteDataSource.detail(
+        id: id,
+        lang: lang,
+        domain: domain,
+      );
+
+      if (result.data == null) {
+        throw const UnitNotAvailableException();
+      }
+
+      return Result.success(
+        ApiResponse<UnitData>(
+          data: result.data,
+          status: result.status,
+          message: result.message,
+          pagination: result.pagination,
+          dataAvailability: result.dataAvailability,
+        ),
+      );
+    } catch (e, s) {
+      _log.console(e.toString(), error: e, stackTrace: s, type: LogType.error);
+      return Result.failure(UnitFailure(message: e.toString()));
+    }
+  }
+
+  @override
   Future<Result<Failure, ApiResponse<List<UnitData>>>> get({
     required String domain,
     DataLanguage lang = DataLanguage.id,

--- a/packages/stadata_flutter_sdk/lib/src/features/units/domain/repositories/unit_data_repository.dart
+++ b/packages/stadata_flutter_sdk/lib/src/features/units/domain/repositories/unit_data_repository.dart
@@ -9,4 +9,9 @@ abstract class UnitDataRepository {
     int page = 1,
     int? variableID,
   });
+  Future<Result<Failure, ApiResponse<UnitData>>> detail({
+    required int id,
+    required String domain,
+    DataLanguage lang = DataLanguage.id,
+  });
 }

--- a/packages/stadata_flutter_sdk/lib/src/features/units/domain/usecases/get_detail_unit.dart
+++ b/packages/stadata_flutter_sdk/lib/src/features/units/domain/usecases/get_detail_unit.dart
@@ -1,0 +1,30 @@
+import 'package:stadata_flutter_sdk/src/base/usecase.dart';
+import 'package:stadata_flutter_sdk/src/core/core.dart';
+import 'package:stadata_flutter_sdk/src/features/features.dart';
+import 'package:stadata_flutter_sdk/src/shared/shared.dart';
+
+class GetDetailUnit
+    implements
+        UseCase<ApiResponse<UnitData>, GetDetailUnitParam, UnitDataRepository> {
+  @override
+  Future<Result<Failure, ApiResponse<UnitData>>> call(
+    GetDetailUnitParam param,
+  ) => repo.detail(id: param.id, lang: param.lang, domain: param.domain);
+
+  @override
+  UnitDataRepository get repo => injector.get<UnitDataRepository>();
+}
+
+class GetDetailUnitParam extends BaseEntity {
+  const GetDetailUnitParam({
+    required this.id,
+    required this.domain,
+    this.lang = DataLanguage.id,
+  });
+  final int id;
+  final String domain;
+  final DataLanguage lang;
+
+  @override
+  List<Object> get props => [id, domain, lang];
+}

--- a/packages/stadata_flutter_sdk/lib/src/features/units/domain/usecases/usecases.dart
+++ b/packages/stadata_flutter_sdk/lib/src/features/units/domain/usecases/usecases.dart
@@ -1,1 +1,2 @@
 export 'get_all_units.dart';
+export 'get_detail_unit.dart';

--- a/packages/stadata_flutter_sdk/lib/src/features/units/injector/unit_injector.dart
+++ b/packages/stadata_flutter_sdk/lib/src/features/units/injector/unit_injector.dart
@@ -15,6 +15,7 @@ class UnitInjector implements ModuleInjector {
         ..registerLazySingleton<UnitDataRepository>(UnitDataRepositoryImpl.new);
 
   @override
-  void injectUseCases(Injector injector) =>
-      injector..registerLazySingleton<GetAllUnits>(GetAllUnits.new);
+  void injectUseCases(Injector injector) => injector
+    ..registerLazySingleton<GetAllUnits>(GetAllUnits.new)
+    ..registerLazySingleton<GetDetailUnit>(GetDetailUnit.new);
 }

--- a/packages/stadata_flutter_sdk/lib/src/features/variables/data/datasources/variable_remote_data_source.dart
+++ b/packages/stadata_flutter_sdk/lib/src/features/variables/data/datasources/variable_remote_data_source.dart
@@ -11,12 +11,54 @@ abstract class VariableRemoteDataSource {
     int? year,
     int? subjectID,
   });
+  Future<ApiResponseModel<VariableModel?>> detail({
+    required int id,
+    required String domain,
+    DataLanguage lang = DataLanguage.id,
+  });
 }
 
 class VariableRemoteDataSourceImpl implements VariableRemoteDataSource {
   final NetworkClient _listHttpModule = injector.get<NetworkClient>(
     instanceName: InjectorConstant.listClient,
   );
+  final NetworkClient _detailClient = injector.get<NetworkClient>(
+    instanceName: InjectorConstant.viewClient,
+  );
+
+  @override
+  Future<ApiResponseModel<VariableModel?>> detail({
+    required int id,
+    required String domain,
+    DataLanguage lang = DataLanguage.id,
+  }) async {
+    final result = await _detailClient.get<JSON>(
+      ApiEndpoint.variable,
+      queryParams: {
+        QueryParamConstant.id: id,
+        QueryParamConstant.domain: domain,
+        QueryParamConstant.lang: lang.value,
+      },
+    );
+
+    if (result.containsKey('status') && result['status'] == 'Error') {
+      throw ApiException(result['message']?.toString() ?? '');
+    }
+
+    final response = ApiResponseModel<VariableModel?>.fromJson(result, (json) {
+      if (json == null) {
+        return null;
+      }
+
+      return VariableModel.fromJson(json as JSON);
+    });
+
+    if (response.dataAvailability == DataAvailability.notAvailable) {
+      throw const VariableNotAvailableException();
+    }
+
+    return response;
+  }
 
   @override
   Future<ApiResponseModel<List<VariableModel>?>> get({

--- a/packages/stadata_flutter_sdk/lib/src/features/variables/data/repositories/variable_repository_impl.dart
+++ b/packages/stadata_flutter_sdk/lib/src/features/variables/data/repositories/variable_repository_impl.dart
@@ -10,6 +10,38 @@ class VariableRepositoryImpl implements VariableRepository {
   final Log _log = injector.get<Log>();
 
   @override
+  Future<Result<Failure, ApiResponse<Variable>>> detail({
+    required int id,
+    required String domain,
+    DataLanguage lang = DataLanguage.id,
+  }) async {
+    try {
+      final result = await _remoteDataSource.detail(
+        id: id,
+        lang: lang,
+        domain: domain,
+      );
+
+      if (result.data == null) {
+        throw const VariableNotAvailableException();
+      }
+
+      return Result.success(
+        ApiResponse<Variable>(
+          data: result.data,
+          status: result.status,
+          message: result.message,
+          pagination: result.pagination,
+          dataAvailability: result.dataAvailability,
+        ),
+      );
+    } catch (e, s) {
+      _log.console(e.toString(), error: e, stackTrace: s, type: LogType.error);
+      return Result.failure(VariableFailure(message: e.toString()));
+    }
+  }
+
+  @override
   Future<Result<Failure, ApiResponse<List<Variable>>>> get({
     required String domain,
     int page = 1,

--- a/packages/stadata_flutter_sdk/lib/src/features/variables/domain/repositories/variable_repository.dart
+++ b/packages/stadata_flutter_sdk/lib/src/features/variables/domain/repositories/variable_repository.dart
@@ -11,4 +11,9 @@ abstract class VariableRepository {
     int? year,
     int? subjectID,
   });
+  Future<Result<Failure, ApiResponse<Variable>>> detail({
+    required int id,
+    required String domain,
+    DataLanguage lang = DataLanguage.id,
+  });
 }

--- a/packages/stadata_flutter_sdk/lib/src/features/variables/domain/usecases/get_detail_variable.dart
+++ b/packages/stadata_flutter_sdk/lib/src/features/variables/domain/usecases/get_detail_variable.dart
@@ -1,0 +1,34 @@
+import 'package:stadata_flutter_sdk/src/base/usecase.dart';
+import 'package:stadata_flutter_sdk/src/core/core.dart';
+import 'package:stadata_flutter_sdk/src/features/features.dart';
+import 'package:stadata_flutter_sdk/src/shared/shared.dart';
+
+class GetDetailVariable
+    implements
+        UseCase<
+          ApiResponse<Variable>,
+          GetDetailVariableParam,
+          VariableRepository
+        > {
+  @override
+  Future<Result<Failure, ApiResponse<Variable>>> call(
+    GetDetailVariableParam param,
+  ) => repo.detail(id: param.id, lang: param.lang, domain: param.domain);
+
+  @override
+  VariableRepository get repo => injector.get<VariableRepository>();
+}
+
+class GetDetailVariableParam extends BaseEntity {
+  const GetDetailVariableParam({
+    required this.id,
+    required this.domain,
+    this.lang = DataLanguage.id,
+  });
+  final int id;
+  final String domain;
+  final DataLanguage lang;
+
+  @override
+  List<Object> get props => [id, domain, lang];
+}

--- a/packages/stadata_flutter_sdk/lib/src/features/variables/domain/usecases/usecases.dart
+++ b/packages/stadata_flutter_sdk/lib/src/features/variables/domain/usecases/usecases.dart
@@ -1,1 +1,2 @@
 export 'get_all_variables.dart';
+export 'get_detail_variable.dart';

--- a/packages/stadata_flutter_sdk/lib/src/features/variables/injector/variable_injector.dart
+++ b/packages/stadata_flutter_sdk/lib/src/features/variables/injector/variable_injector.dart
@@ -15,6 +15,7 @@ class VariableInjector implements ModuleInjector {
         ..registerLazySingleton<VariableRepository>(VariableRepositoryImpl.new);
 
   @override
-  void injectUseCases(Injector injector) =>
-      injector..registerLazySingleton<GetAllVariables>(GetAllVariables.new);
+  void injectUseCases(Injector injector) => injector
+    ..registerLazySingleton<GetAllVariables>(GetAllVariables.new)
+    ..registerLazySingleton<GetDetailVariable>(GetDetailVariable.new);
 }

--- a/packages/stadata_flutter_sdk/lib/src/features/vertical_variables/data/datasources/vertical_variable_remote_data_source.dart
+++ b/packages/stadata_flutter_sdk/lib/src/features/vertical_variables/data/datasources/vertical_variable_remote_data_source.dart
@@ -9,6 +9,11 @@ abstract class VerticalVariableRemoteDataSource {
     DataLanguage lang = DataLanguage.id,
     int? variableID,
   });
+  Future<ApiResponseModel<VerticalVariableModel?>> detail({
+    required int id,
+    required String domain,
+    DataLanguage lang = DataLanguage.id,
+  });
 }
 
 class VerticalVariableRemoteDataSourceImpl
@@ -16,6 +21,46 @@ class VerticalVariableRemoteDataSourceImpl
   final NetworkClient _listHttpModule = injector.get<NetworkClient>(
     instanceName: InjectorConstant.listClient,
   );
+  final NetworkClient _detailClient = injector.get<NetworkClient>(
+    instanceName: InjectorConstant.viewClient,
+  );
+
+  @override
+  Future<ApiResponseModel<VerticalVariableModel?>> detail({
+    required int id,
+    required String domain,
+    DataLanguage lang = DataLanguage.id,
+  }) async {
+    final result = await _detailClient.get<JSON>(
+      ApiEndpoint.verticalVariable,
+      queryParams: {
+        QueryParamConstant.id: id,
+        QueryParamConstant.domain: domain,
+        QueryParamConstant.lang: lang.value,
+      },
+    );
+
+    if (result.containsKey('status') && result['status'] == 'Error') {
+      throw ApiException(result['message']?.toString() ?? '');
+    }
+
+    final response = ApiResponseModel<VerticalVariableModel?>.fromJson(
+      result,
+      (json) {
+        if (json == null) {
+          return null;
+        }
+
+        return VerticalVariableModel.fromJson(json as JSON);
+      },
+    );
+
+    if (response.dataAvailability == DataAvailability.notAvailable) {
+      throw const VerticalVariableNotAvailableException();
+    }
+
+    return response;
+  }
 
   @override
   Future<ApiResponseModel<List<VerticalVariableModel>?>> get({

--- a/packages/stadata_flutter_sdk/lib/src/features/vertical_variables/data/repositories/vertical_variable_repository_impl.dart
+++ b/packages/stadata_flutter_sdk/lib/src/features/vertical_variables/data/repositories/vertical_variable_repository_impl.dart
@@ -10,6 +10,38 @@ class VerticalVariableRepositoryImpl implements VerticalVariableRepository {
   final Log _log = injector.get<Log>();
 
   @override
+  Future<Result<Failure, ApiResponse<VerticalVariable>>> detail({
+    required int id,
+    required String domain,
+    DataLanguage lang = DataLanguage.id,
+  }) async {
+    try {
+      final result = await _remoteDataSource.detail(
+        id: id,
+        lang: lang,
+        domain: domain,
+      );
+
+      if (result.data == null) {
+        throw const VerticalVariableNotAvailableException();
+      }
+
+      return Result.success(
+        ApiResponse<VerticalVariable>(
+          data: result.data,
+          status: result.status,
+          message: result.message,
+          pagination: result.pagination,
+          dataAvailability: result.dataAvailability,
+        ),
+      );
+    } catch (e, s) {
+      _log.console(e.toString(), error: e, stackTrace: s, type: LogType.error);
+      return Result.failure(VerticalVariableFailure(message: e.toString()));
+    }
+  }
+
+  @override
   Future<Result<Failure, ApiResponse<List<VerticalVariable>>>> get({
     required String domain,
     int page = 1,

--- a/packages/stadata_flutter_sdk/lib/src/features/vertical_variables/domain/repositories/vertical_variable_repository.dart
+++ b/packages/stadata_flutter_sdk/lib/src/features/vertical_variables/domain/repositories/vertical_variable_repository.dart
@@ -9,4 +9,9 @@ abstract class VerticalVariableRepository {
     DataLanguage lang = DataLanguage.id,
     int? variableID,
   });
+  Future<Result<Failure, ApiResponse<VerticalVariable>>> detail({
+    required int id,
+    required String domain,
+    DataLanguage lang = DataLanguage.id,
+  });
 }

--- a/packages/stadata_flutter_sdk/lib/src/features/vertical_variables/domain/usecases/get_detail_vertical_variable.dart
+++ b/packages/stadata_flutter_sdk/lib/src/features/vertical_variables/domain/usecases/get_detail_vertical_variable.dart
@@ -1,0 +1,35 @@
+import 'package:stadata_flutter_sdk/src/base/usecase.dart';
+import 'package:stadata_flutter_sdk/src/core/core.dart';
+import 'package:stadata_flutter_sdk/src/features/features.dart';
+import 'package:stadata_flutter_sdk/src/shared/shared.dart';
+
+class GetDetailVerticalVariable
+    implements
+        UseCase<
+          ApiResponse<VerticalVariable>,
+          GetDetailVerticalVariableParam,
+          VerticalVariableRepository
+        > {
+  @override
+  Future<Result<Failure, ApiResponse<VerticalVariable>>> call(
+    GetDetailVerticalVariableParam param,
+  ) => repo.detail(id: param.id, lang: param.lang, domain: param.domain);
+
+  @override
+  VerticalVariableRepository get repo =>
+      injector.get<VerticalVariableRepository>();
+}
+
+class GetDetailVerticalVariableParam extends BaseEntity {
+  const GetDetailVerticalVariableParam({
+    required this.id,
+    required this.domain,
+    this.lang = DataLanguage.id,
+  });
+  final int id;
+  final String domain;
+  final DataLanguage lang;
+
+  @override
+  List<Object> get props => [id, domain, lang];
+}

--- a/packages/stadata_flutter_sdk/lib/src/features/vertical_variables/domain/usecases/usecases.dart
+++ b/packages/stadata_flutter_sdk/lib/src/features/vertical_variables/domain/usecases/usecases.dart
@@ -1,1 +1,2 @@
 export 'get_all_vertical_variables.dart';
+export 'get_detail_vertical_variable.dart';

--- a/packages/stadata_flutter_sdk/lib/src/features/vertical_variables/injector/vertical_variable_injector.dart
+++ b/packages/stadata_flutter_sdk/lib/src/features/vertical_variables/injector/vertical_variable_injector.dart
@@ -16,8 +16,11 @@ class VerticalVariableInjector implements ModuleInjector {
       );
 
   @override
-  void injectUseCases(Injector injector) =>
-      injector..registerLazySingleton<GetAllVerticalVariables>(
-        GetAllVerticalVariables.new,
-      );
+  void injectUseCases(Injector injector) => injector
+    ..registerLazySingleton<GetAllVerticalVariables>(
+      GetAllVerticalVariables.new,
+    )
+    ..registerLazySingleton<GetDetailVerticalVariable>(
+      GetDetailVerticalVariable.new,
+    );
 }

--- a/packages/stadata_flutter_sdk/lib/src/view/view.dart
+++ b/packages/stadata_flutter_sdk/lib/src/view/view.dart
@@ -69,6 +69,72 @@ abstract class StadataView {
     int page = 1,
     int perPage = 10,
   });
+
+  Future<Subject?> subject({
+    required int id,
+    required String domain,
+    DataLanguage lang = DataLanguage.id,
+  });
+
+  Future<SubjectCategory?> subjectCategory({
+    required int id,
+    required String domain,
+    DataLanguage lang = DataLanguage.id,
+  });
+
+  Future<StrategicIndicator?> strategicIndicator({
+    required int id,
+    required String domain,
+    DataLanguage lang = DataLanguage.id,
+  });
+
+  Future<Variable?> variable({
+    required int id,
+    required String domain,
+    DataLanguage lang = DataLanguage.id,
+  });
+
+  Future<VerticalVariable?> verticalVariable({
+    required int id,
+    required String domain,
+    DataLanguage lang = DataLanguage.id,
+  });
+
+  Future<Infographic?> infographic({
+    required int id,
+    required String domain,
+    DataLanguage lang = DataLanguage.id,
+  });
+
+  Future<Period?> period({
+    required int id,
+    required String domain,
+    DataLanguage lang = DataLanguage.id,
+  });
+
+  Future<DerivedPeriod?> derivedPeriod({
+    required int id,
+    required String domain,
+    DataLanguage lang = DataLanguage.id,
+  });
+
+  Future<DerivedVariable?> derivedVariable({
+    required int id,
+    required String domain,
+    DataLanguage lang = DataLanguage.id,
+  });
+
+  Future<NewsCategory?> newsCategory({
+    required String id,
+    required String domain,
+    DataLanguage lang = DataLanguage.id,
+  });
+
+  Future<UnitData?> unit({
+    required int id,
+    required String domain,
+    DataLanguage lang = DataLanguage.id,
+  });
 }
 
 /// Implementation of the [StadataView] interface.
@@ -85,6 +151,25 @@ class StadataViewImpl implements StadataView {
       .get<GetDetailPressRelease>();
   final GetDetailStatisticClassification _getDetailStatisticClassification =
       injector.get<GetDetailStatisticClassification>();
+  final GetDetailSubject _getDetailSubject = injector.get<GetDetailSubject>();
+  final GetDetailSubjectCategory _getDetailSubjectCategory = injector
+      .get<GetDetailSubjectCategory>();
+  final GetDetailStrategicIndicator _getDetailStrategicIndicator = injector
+      .get<GetDetailStrategicIndicator>();
+  final GetDetailVariable _getDetailVariable = injector
+      .get<GetDetailVariable>();
+  final GetDetailVerticalVariable _getDetailVerticalVariable = injector
+      .get<GetDetailVerticalVariable>();
+  final GetDetailInfographic _getDetailInfographic = injector
+      .get<GetDetailInfographic>();
+  final GetDetailPeriod _getDetailPeriod = injector.get<GetDetailPeriod>();
+  final GetDetailDerivedPeriod _getDetailDerivedPeriod = injector
+      .get<GetDetailDerivedPeriod>();
+  final GetDetailDerivedVariable _getDetailDerivedVariable = injector
+      .get<GetDetailDerivedVariable>();
+  final GetDetailNewsCategory _getDetailNewsCategory = injector
+      .get<GetDetailNewsCategory>();
+  final GetDetailUnit _getDetailUnit = injector.get<GetDetailUnit>();
 
   @override
   Future<Publication?> publication({
@@ -170,6 +255,182 @@ class StadataViewImpl implements StadataView {
 
     return result.fold(
       (l) => throw StatisticClassificationException(message: l.message),
+      (r) => r.data,
+    );
+  }
+
+  @override
+  Future<Subject?> subject({
+    required int id,
+    required String domain,
+    DataLanguage lang = DataLanguage.id,
+  }) async {
+    final result = await _getDetailSubject(
+      GetDetailSubjectParam(id: id, lang: lang, domain: domain),
+    );
+
+    return result.fold(
+      (l) => throw SubjectException(message: l.message),
+      (r) => r.data,
+    );
+  }
+
+  @override
+  Future<SubjectCategory?> subjectCategory({
+    required int id,
+    required String domain,
+    DataLanguage lang = DataLanguage.id,
+  }) async {
+    final result = await _getDetailSubjectCategory(
+      GetDetailSubjectCategoryParam(id: id, lang: lang, domain: domain),
+    );
+
+    return result.fold(
+      (l) => throw SubjectCategoryException(message: l.message),
+      (r) => r.data,
+    );
+  }
+
+  @override
+  Future<StrategicIndicator?> strategicIndicator({
+    required int id,
+    required String domain,
+    DataLanguage lang = DataLanguage.id,
+  }) async {
+    final result = await _getDetailStrategicIndicator(
+      GetDetailStrategicIndicatorParam(id: id, lang: lang, domain: domain),
+    );
+
+    return result.fold(
+      (l) => throw StrategicIndicatorException(message: l.message),
+      (r) => r.data,
+    );
+  }
+
+  @override
+  Future<Variable?> variable({
+    required int id,
+    required String domain,
+    DataLanguage lang = DataLanguage.id,
+  }) async {
+    final result = await _getDetailVariable(
+      GetDetailVariableParam(id: id, lang: lang, domain: domain),
+    );
+
+    return result.fold(
+      (l) => throw VariableException(message: l.message),
+      (r) => r.data,
+    );
+  }
+
+  @override
+  Future<VerticalVariable?> verticalVariable({
+    required int id,
+    required String domain,
+    DataLanguage lang = DataLanguage.id,
+  }) async {
+    final result = await _getDetailVerticalVariable(
+      GetDetailVerticalVariableParam(id: id, lang: lang, domain: domain),
+    );
+
+    return result.fold(
+      (l) => throw VerticalVariableException(message: l.message),
+      (r) => r.data,
+    );
+  }
+
+  @override
+  Future<Infographic?> infographic({
+    required int id,
+    required String domain,
+    DataLanguage lang = DataLanguage.id,
+  }) async {
+    final result = await _getDetailInfographic(
+      GetDetailInfographicParam(id: id, lang: lang, domain: domain),
+    );
+
+    return result.fold(
+      (l) => throw InfographicException(message: l.message),
+      (r) => r.data,
+    );
+  }
+
+  @override
+  Future<Period?> period({
+    required int id,
+    required String domain,
+    DataLanguage lang = DataLanguage.id,
+  }) async {
+    final result = await _getDetailPeriod(
+      GetDetailPeriodParam(id: id, lang: lang, domain: domain),
+    );
+
+    return result.fold(
+      (l) => throw PeriodException(message: l.message),
+      (r) => r.data,
+    );
+  }
+
+  @override
+  Future<DerivedPeriod?> derivedPeriod({
+    required int id,
+    required String domain,
+    DataLanguage lang = DataLanguage.id,
+  }) async {
+    final result = await _getDetailDerivedPeriod(
+      GetDetailDerivedPeriodParam(id: id, lang: lang, domain: domain),
+    );
+
+    return result.fold(
+      (l) => throw DerivedPeriodException(message: l.message),
+      (r) => r.data,
+    );
+  }
+
+  @override
+  Future<DerivedVariable?> derivedVariable({
+    required int id,
+    required String domain,
+    DataLanguage lang = DataLanguage.id,
+  }) async {
+    final result = await _getDetailDerivedVariable(
+      GetDetailDerivedVariableParam(id: id, lang: lang, domain: domain),
+    );
+
+    return result.fold(
+      (l) => throw DerivedVariableException(message: l.message),
+      (r) => r.data,
+    );
+  }
+
+  @override
+  Future<NewsCategory?> newsCategory({
+    required String id,
+    required String domain,
+    DataLanguage lang = DataLanguage.id,
+  }) async {
+    final result = await _getDetailNewsCategory(
+      GetDetailNewsCategoryParam(id: id, lang: lang, domain: domain),
+    );
+
+    return result.fold(
+      (l) => throw NewsCategoryException(message: l.message),
+      (r) => r.data,
+    );
+  }
+
+  @override
+  Future<UnitData?> unit({
+    required int id,
+    required String domain,
+    DataLanguage lang = DataLanguage.id,
+  }) async {
+    final result = await _getDetailUnit(
+      GetDetailUnitParam(id: id, lang: lang, domain: domain),
+    );
+
+    return result.fold(
+      (l) => throw UnitException(message: l.message),
       (r) => r.data,
     );
   }

--- a/packages/stadata_flutter_sdk/test/src/features/derived_periods/data/datasources/derived_period_remote_data_source_test.dart
+++ b/packages/stadata_flutter_sdk/test/src/features/derived_periods/data/datasources/derived_period_remote_data_source_test.dart
@@ -22,6 +22,10 @@ void main() {
       mockListClient,
       instanceName: 'listClient',
     );
+    registerTestFactory<NetworkClient>(
+      mockListClient,
+      instanceName: 'viewClient',
+    );
     dataSource = DerivedPeriodRemoteDataSourceImpl();
 
     response = jsonFromFixture(Fixture.derivedPeriods);

--- a/packages/stadata_flutter_sdk/test/src/features/derived_variables/data/datasources/derived_variable_remote_data_source_test.dart
+++ b/packages/stadata_flutter_sdk/test/src/features/derived_variables/data/datasources/derived_variable_remote_data_source_test.dart
@@ -22,6 +22,10 @@ void main() {
       mockListClient,
       instanceName: 'listClient',
     );
+    registerTestFactory<NetworkClient>(
+      mockListClient,
+      instanceName: 'viewClient',
+    );
     dataSource = DerivedVariableRemoteDataSourceImpl();
 
     response = jsonFromFixture(Fixture.derivedVariables);

--- a/packages/stadata_flutter_sdk/test/src/features/infographics/data/datasources/infographic_remote_data_source_test.dart
+++ b/packages/stadata_flutter_sdk/test/src/features/infographics/data/datasources/infographic_remote_data_source_test.dart
@@ -22,6 +22,10 @@ void main() {
       mockNetworkClient,
       instanceName: 'listClient',
     );
+    registerTestFactory<NetworkClient>(
+      mockNetworkClient,
+      instanceName: 'viewClient',
+    );
     dataSource = InfographicRemoteDataSourceImpl();
 
     listResponse = jsonFromFixture(Fixture.infographics);

--- a/packages/stadata_flutter_sdk/test/src/features/news_categories/data/datasources/news_category_remote_data_source_test.dart
+++ b/packages/stadata_flutter_sdk/test/src/features/news_categories/data/datasources/news_category_remote_data_source_test.dart
@@ -22,6 +22,10 @@ void main() {
       mockListClient,
       instanceName: 'listClient',
     );
+    registerTestFactory<NetworkClient>(
+      mockListClient,
+      instanceName: 'viewClient',
+    );
     dataSource = NewsCategoryRemoteDataSourceImpl();
 
     response = jsonFromFixture(Fixture.newsCategory);

--- a/packages/stadata_flutter_sdk/test/src/features/periods/data/datasources/period_remote_data_source_test.dart
+++ b/packages/stadata_flutter_sdk/test/src/features/periods/data/datasources/period_remote_data_source_test.dart
@@ -22,6 +22,10 @@ void main() {
       mockListClient,
       instanceName: 'listClient',
     );
+    registerTestFactory<NetworkClient>(
+      mockListClient,
+      instanceName: 'viewClient',
+    );
     dataSource = PeriodRemoteDataSourceImpl();
 
     response = jsonFromFixture(Fixture.periods);

--- a/packages/stadata_flutter_sdk/test/src/features/strategic_indicators/data/datasources/strategic_indicator_remote_data_source_test.dart
+++ b/packages/stadata_flutter_sdk/test/src/features/strategic_indicators/data/datasources/strategic_indicator_remote_data_source_test.dart
@@ -19,6 +19,10 @@ void main() {
       mockListClient,
       instanceName: 'listClient',
     );
+    registerTestFactory<NetworkClient>(
+      mockListClient,
+      instanceName: 'viewClient',
+    );
     dataSource = StrategicIndicatorRemoteDataSourceImpl();
   });
 

--- a/packages/stadata_flutter_sdk/test/src/features/subject_categories/data/datasources/subject_category_remote_data_source_test.dart
+++ b/packages/stadata_flutter_sdk/test/src/features/subject_categories/data/datasources/subject_category_remote_data_source_test.dart
@@ -22,6 +22,10 @@ void main() {
       mockListClient,
       instanceName: 'listClient',
     );
+    registerTestFactory<NetworkClient>(
+      mockListClient,
+      instanceName: 'viewClient',
+    );
     dataSource = SubjectCategoryRemoteDataSourceImpl();
 
     response = jsonFromFixture(Fixture.subjectCategories);

--- a/packages/stadata_flutter_sdk/test/src/features/subjects/data/datasources/subject_remote_data_source_test.dart
+++ b/packages/stadata_flutter_sdk/test/src/features/subjects/data/datasources/subject_remote_data_source_test.dart
@@ -22,6 +22,10 @@ void main() {
       mockListClient,
       instanceName: 'listClient',
     );
+    registerTestFactory<NetworkClient>(
+      mockListClient,
+      instanceName: 'viewClient',
+    );
     dataSource = SubjectRemoteDataSourceImpl();
 
     response = jsonFromFixture(Fixture.subjects);

--- a/packages/stadata_flutter_sdk/test/src/features/units/data/datasources/unit_data_remote_data_source_test.dart
+++ b/packages/stadata_flutter_sdk/test/src/features/units/data/datasources/unit_data_remote_data_source_test.dart
@@ -22,6 +22,10 @@ void main() {
       mockListClient,
       instanceName: 'listClient',
     );
+    registerTestFactory<NetworkClient>(
+      mockListClient,
+      instanceName: 'viewClient',
+    );
     dataSource = UnitDataRemoteDataSourceImpl();
 
     response = jsonFromFixture(Fixture.units);

--- a/packages/stadata_flutter_sdk/test/src/features/variables/data/datasources/variable_remote_data_source_test.dart
+++ b/packages/stadata_flutter_sdk/test/src/features/variables/data/datasources/variable_remote_data_source_test.dart
@@ -22,6 +22,10 @@ void main() {
       mockListClient,
       instanceName: 'listClient',
     );
+    registerTestFactory<NetworkClient>(
+      mockListClient,
+      instanceName: 'viewClient',
+    );
     dataSource = VariableRemoteDataSourceImpl();
 
     response = jsonFromFixture(Fixture.variables);

--- a/packages/stadata_flutter_sdk/test/src/features/vertical_variables/data/datasources/vertical_variable_remote_data_source_test.dart
+++ b/packages/stadata_flutter_sdk/test/src/features/vertical_variables/data/datasources/vertical_variable_remote_data_source_test.dart
@@ -22,6 +22,10 @@ void main() {
       mockListClient,
       instanceName: 'listClient',
     );
+    registerTestFactory<NetworkClient>(
+      mockListClient,
+      instanceName: 'viewClient',
+    );
     dataSource = VerticalVariableRemoteDataSourceImpl();
 
     response = jsonFromFixture(Fixture.verticalVariables);

--- a/packages/stadata_flutter_sdk/test/src/view/view_test.dart
+++ b/packages/stadata_flutter_sdk/test/src/view/view_test.dart
@@ -19,12 +19,50 @@ class MockGetDetailPressRelease extends Mock implements GetDetailPressRelease {}
 class MockGetDetailStatisticClassification extends Mock
     implements GetDetailStatisticClassification {}
 
+class MockGetDetailSubject extends Mock implements GetDetailSubject {}
+
+class MockGetDetailSubjectCategory extends Mock
+    implements GetDetailSubjectCategory {}
+
+class MockGetDetailStrategicIndicator extends Mock
+    implements GetDetailStrategicIndicator {}
+
+class MockGetDetailVariable extends Mock implements GetDetailVariable {}
+
+class MockGetDetailVerticalVariable extends Mock
+    implements GetDetailVerticalVariable {}
+
+class MockGetDetailInfographic extends Mock implements GetDetailInfographic {}
+
+class MockGetDetailPeriod extends Mock implements GetDetailPeriod {}
+
+class MockGetDetailDerivedPeriod extends Mock
+    implements GetDetailDerivedPeriod {}
+
+class MockGetDetailDerivedVariable extends Mock
+    implements GetDetailDerivedVariable {}
+
+class MockGetDetailNewsCategory extends Mock implements GetDetailNewsCategory {}
+
+class MockGetDetailUnit extends Mock implements GetDetailUnit {}
+
 void main() {
   late GetDetailNews mockGetDetailNews;
   late GetDetailPublication mockGetDetailPublication;
   late GetDetailStaticTable mockGetDetailStaticTable;
   late GetDetailPressRelease mockGetDetailPressRelease;
   late GetDetailStatisticClassification mockGetDetailStatisticClassification;
+  late GetDetailSubject mockGetDetailSubject;
+  late GetDetailSubjectCategory mockGetDetailSubjectCategory;
+  late GetDetailStrategicIndicator mockGetDetailStrategicIndicator;
+  late GetDetailVariable mockGetDetailVariable;
+  late GetDetailVerticalVariable mockGetDetailVerticalVariable;
+  late GetDetailInfographic mockGetDetailInfographic;
+  late GetDetailPeriod mockGetDetailPeriod;
+  late GetDetailDerivedPeriod mockGetDetailDerivedPeriod;
+  late GetDetailDerivedVariable mockGetDetailDerivedVariable;
+  late GetDetailNewsCategory mockGetDetailNewsCategory;
+  late GetDetailUnit mockGetDetailUnit;
   late StadataView stadataView;
 
   setUpAll(() {
@@ -41,6 +79,38 @@ void main() {
     registerTestLazySingleton<GetDetailStatisticClassification>(
       mockGetDetailStatisticClassification,
     );
+    mockGetDetailSubject = MockGetDetailSubject();
+    registerTestLazySingleton<GetDetailSubject>(mockGetDetailSubject);
+    mockGetDetailSubjectCategory = MockGetDetailSubjectCategory();
+    registerTestLazySingleton<GetDetailSubjectCategory>(
+      mockGetDetailSubjectCategory,
+    );
+    mockGetDetailStrategicIndicator = MockGetDetailStrategicIndicator();
+    registerTestLazySingleton<GetDetailStrategicIndicator>(
+      mockGetDetailStrategicIndicator,
+    );
+    mockGetDetailVariable = MockGetDetailVariable();
+    registerTestLazySingleton<GetDetailVariable>(mockGetDetailVariable);
+    mockGetDetailVerticalVariable = MockGetDetailVerticalVariable();
+    registerTestLazySingleton<GetDetailVerticalVariable>(
+      mockGetDetailVerticalVariable,
+    );
+    mockGetDetailInfographic = MockGetDetailInfographic();
+    registerTestLazySingleton<GetDetailInfographic>(mockGetDetailInfographic);
+    mockGetDetailPeriod = MockGetDetailPeriod();
+    registerTestLazySingleton<GetDetailPeriod>(mockGetDetailPeriod);
+    mockGetDetailDerivedPeriod = MockGetDetailDerivedPeriod();
+    registerTestLazySingleton<GetDetailDerivedPeriod>(
+      mockGetDetailDerivedPeriod,
+    );
+    mockGetDetailDerivedVariable = MockGetDetailDerivedVariable();
+    registerTestLazySingleton<GetDetailDerivedVariable>(
+      mockGetDetailDerivedVariable,
+    );
+    mockGetDetailNewsCategory = MockGetDetailNewsCategory();
+    registerTestLazySingleton<GetDetailNewsCategory>(mockGetDetailNewsCategory);
+    mockGetDetailUnit = MockGetDetailUnit();
+    registerTestLazySingleton<GetDetailUnit>(mockGetDetailUnit);
     stadataView = StadataViewImpl();
   });
 
@@ -377,6 +447,201 @@ void main() {
           () => mockGetDetailStatisticClassification(
             GetDetailStatisticClassificationParam(id: id, type: type),
           ),
+        );
+      });
+    });
+
+    group('subject()', () {
+      const id = 1;
+
+      test('should throw Exception if failure occured', () async {
+        when(
+          () => mockGetDetailSubject(
+            const GetDetailSubjectParam(id: id, domain: domain),
+          ),
+        ).thenAnswer((_) async => Result.failure(const SubjectFailure()));
+
+        expect(
+          () => stadataView.subject(id: id, domain: domain),
+          throwsA(isA<SubjectException>()),
+        );
+      });
+    });
+
+    group('subjectCategory()', () {
+      const id = 1;
+
+      test('should throw Exception if failure occured', () async {
+        when(
+          () => mockGetDetailSubjectCategory(
+            const GetDetailSubjectCategoryParam(id: id, domain: domain),
+          ),
+        ).thenAnswer(
+          (_) async => Result.failure(const SubjectCategoryFailure()),
+        );
+
+        expect(
+          () => stadataView.subjectCategory(id: id, domain: domain),
+          throwsA(isA<SubjectCategoryException>()),
+        );
+      });
+    });
+
+    group('strategicIndicator()', () {
+      const id = 1;
+
+      test('should throw Exception if failure occured', () async {
+        when(
+          () => mockGetDetailStrategicIndicator(
+            const GetDetailStrategicIndicatorParam(id: id, domain: domain),
+          ),
+        ).thenAnswer(
+          (_) async => Result.failure(const StrategicIndicatorFailure()),
+        );
+
+        expect(
+          () => stadataView.strategicIndicator(id: id, domain: domain),
+          throwsA(isA<StrategicIndicatorException>()),
+        );
+      });
+    });
+
+    group('variable()', () {
+      const id = 1;
+
+      test('should throw Exception if failure occured', () async {
+        when(
+          () => mockGetDetailVariable(
+            const GetDetailVariableParam(id: id, domain: domain),
+          ),
+        ).thenAnswer((_) async => Result.failure(const VariableFailure()));
+
+        expect(
+          () => stadataView.variable(id: id, domain: domain),
+          throwsA(isA<VariableException>()),
+        );
+      });
+    });
+
+    group('verticalVariable()', () {
+      const id = 1;
+
+      test('should throw Exception if failure occured', () async {
+        when(
+          () => mockGetDetailVerticalVariable(
+            const GetDetailVerticalVariableParam(id: id, domain: domain),
+          ),
+        ).thenAnswer(
+          (_) async => Result.failure(const VerticalVariableFailure()),
+        );
+
+        expect(
+          () => stadataView.verticalVariable(id: id, domain: domain),
+          throwsA(isA<VerticalVariableException>()),
+        );
+      });
+    });
+
+    group('infographic()', () {
+      const id = 1;
+
+      test('should throw Exception if failure occured', () async {
+        when(
+          () => mockGetDetailInfographic(
+            const GetDetailInfographicParam(id: id, domain: domain),
+          ),
+        ).thenAnswer((_) async => Result.failure(const InfographicFailure()));
+
+        expect(
+          () => stadataView.infographic(id: id, domain: domain),
+          throwsA(isA<InfographicException>()),
+        );
+      });
+    });
+
+    group('period()', () {
+      const id = 1;
+
+      test('should throw Exception if failure occured', () async {
+        when(
+          () => mockGetDetailPeriod(
+            const GetDetailPeriodParam(id: id, domain: domain),
+          ),
+        ).thenAnswer((_) async => Result.failure(const PeriodFailure()));
+
+        expect(
+          () => stadataView.period(id: id, domain: domain),
+          throwsA(isA<PeriodException>()),
+        );
+      });
+    });
+
+    group('derivedPeriod()', () {
+      const id = 1;
+
+      test('should throw Exception if failure occured', () async {
+        when(
+          () => mockGetDetailDerivedPeriod(
+            const GetDetailDerivedPeriodParam(id: id, domain: domain),
+          ),
+        ).thenAnswer((_) async => Result.failure(const DerivedPeriodFailure()));
+
+        expect(
+          () => stadataView.derivedPeriod(id: id, domain: domain),
+          throwsA(isA<DerivedPeriodException>()),
+        );
+      });
+    });
+
+    group('derivedVariable()', () {
+      const id = 1;
+
+      test('should throw Exception if failure occured', () async {
+        when(
+          () => mockGetDetailDerivedVariable(
+            const GetDetailDerivedVariableParam(id: id, domain: domain),
+          ),
+        ).thenAnswer(
+          (_) async => Result.failure(const DerivedVariableFailure()),
+        );
+
+        expect(
+          () => stadataView.derivedVariable(id: id, domain: domain),
+          throwsA(isA<DerivedVariableException>()),
+        );
+      });
+    });
+
+    group('newsCategory()', () {
+      const id = 'cat-1';
+
+      test('should throw Exception if failure occured', () async {
+        when(
+          () => mockGetDetailNewsCategory(
+            const GetDetailNewsCategoryParam(id: id, domain: domain),
+          ),
+        ).thenAnswer((_) async => Result.failure(const NewsCategoryFailure()));
+
+        expect(
+          () => stadataView.newsCategory(id: id, domain: domain),
+          throwsA(isA<NewsCategoryException>()),
+        );
+      });
+    });
+
+    group('unit()', () {
+      const id = 1;
+
+      test('should throw Exception if failure occured', () async {
+        when(
+          () => mockGetDetailUnit(
+            const GetDetailUnitParam(id: id, domain: domain),
+          ),
+        ).thenAnswer((_) async => Result.failure(const UnitFailure()));
+
+        expect(
+          () => stadataView.unit(id: id, domain: domain),
+          throwsA(isA<UnitException>()),
         );
       });
     });


### PR DESCRIPTION
## Summary

- Adds `detail()` datasource, repository, use case, and DI registration for 11 features: `subject`, `subjectCategory`, `strategicIndicator`, `variable`, `verticalVariable`, `infographic`, `period`, `derivedPeriod`, `derivedVariable`, `newsCategory`, `unit`
- Exposes all 11 as methods on `StadataView` abstract class and `StadataViewImpl`
- Fixes exhaustive switch for `KBLIType.y2025` in example app

## Test plan

- [ ] `melos analyze` — no issues
- [ ] `flutter test packages/stadata_flutter_sdk/test/src/view/view_test.dart` — all 21 tests pass
- [ ] Each new `StadataView` method calls the correct use case and throws the feature-specific exception on failure