### PR TITLE
fix(example): handle KBLIType.y2025 in exhaustive switch expressions

### DIFF
--- a/app/example/lib/features/statistical_classifications/presentation/pages/statistical_classifications_results_page.dart
+++ b/app/example/lib/features/statistical_classifications/presentation/pages/statistical_classifications_results_page.dart
@@ -178,6 +178,7 @@ String _getTypeLabel(ClassificationType type) {
       KBLIType.y2015 => 'KBLI 2015',
       KBLIType.y2017 => 'KBLI 2017',
       KBLIType.y2020 => 'KBLI 2020',
+      KBLIType.y2025 => 'KBLI 2025',
     };
   } else if (type is KBKIType) {
     return switch (type) {

--- a/app/example/lib/features/statistical_classifications/presentation/widgets/statistical_classifications_parameters_panel.dart
+++ b/app/example/lib/features/statistical_classifications/presentation/widgets/statistical_classifications_parameters_panel.dart
@@ -136,6 +136,7 @@ class _StatisticalClassificationsParametersPanelState
                               KBLIType.y2015 => 'KBLI 2015',
                               KBLIType.y2017 => 'KBLI 2017',
                               KBLIType.y2020 => 'KBLI 2020',
+                              KBLIType.y2025 => 'KBLI 2025',
                             };
                             return DropdownMenuItem(
                               value: type,


### PR DESCRIPTION
## Summary

- Add `KBLIType.y2025 => 'KBLI 2025'` case to the exhaustive switch in `statistical_classifications_results_page.dart`
- Add `KBLIType.y2025 => 'KBLI 2025'` case to the exhaustive switch in `statistical_classifications_parameters_panel.dart`

## Why

PR #211 added `KBLIType.y2025` to the SDK enum but the example app switch statements were not updated. This caused the APK build CI job to fail on `develop` because the baseline build could not compile.

## Test plan

- [ ] CI APK build job passes on `develop` after merge
- [ ] Example app compiles without errors