### PR TITLE
build(deps): bump auto_route_generator from 10.5.0 to 10.6.0

### DIFF
--- a/app/example/pubspec.yaml
+++ b/app/example/pubspec.yaml
@@ -48,7 +48,7 @@ dependencies:
   easy_stepper: ^1.1.0
 
 dev_dependencies:
-  auto_route_generator: ^10.5.0
+  auto_route_generator: ^10.6.0
   build_runner: ^2.15.0
   envied_generator: ^1.3.5
   flutter_lints: ^6.0.0


### PR DESCRIPTION
Resolves merge conflict from dependabot PR #237 — bumps `auto_route_generator` to ^10.6.0 on top of the already-merged `build_runner` and `injectable_generator` bumps.