### PR TITLE
build(deps): bump slang_flutter from 4.14.0 to 4.17.0

### DIFF
--- a/app/example/pubspec.yaml
+++ b/app/example/pubspec.yaml
@@ -39,7 +39,7 @@ dependencies:
   shared_preferences: ^2.5.5
   skeletonizer: ^2.1.3
   slang: ^4.17.0
-  slang_flutter: ^4.14.0
+  slang_flutter: ^4.17.0
   stadata_flutter_sdk:
     path: ../../packages/stadata_flutter_sdk
   url_launcher: ^6.3.2


### PR DESCRIPTION
Resolves merge conflict from dependabot PR #255 — applies slang_flutter bump on top of already-merged slang and slang_build_runner bumps.