### PR TITLE
build(deps): upgrade example app dependencies to latest versions

### DIFF
--- a/app/example/pubspec.yaml
+++ b/app/example/pubspec.yaml
@@ -15,8 +15,8 @@ dependencies:
   drop_shadow: ^0.1.0
   easy_debounce: ^2.0.3
   easy_stepper: ^1.1.0
-  envied: ^1.3.7
-  equatable: ^2.0.8
+  envied: ^1.3.8
+  equatable: ^2.1.0
   extended_image: ^10.0.1
   flutter:
     sdk: flutter
@@ -38,22 +38,22 @@ dependencies:
   searchable_paginated_dropdown: ^1.3.0
   shared_preferences: ^2.5.5
   skeletonizer: ^2.1.3
-  slang: ^4.17.0
-  slang_flutter: ^4.17.0
+  slang: ^4.18.0
+  slang_flutter: ^4.18.0
   stadata_flutter_sdk:
     path: ../../packages/stadata_flutter_sdk
   url_launcher: ^6.3.2
-  webview_flutter: ^4.14.0
+  webview_flutter: ^4.14.1
 
 dev_dependencies:
   auto_route_generator: ^10.6.0
   build_runner: ^2.15.0
-  envied_generator: ^1.3.7
+  envied_generator: ^1.3.8
   flutter_lints: ^6.0.0
   flutter_test:
     sdk: flutter
   injectable_generator: ^3.1.0
-  slang_build_runner: ^4.17.0
+  slang_build_runner: ^4.18.0
   very_good_analysis: ^10.3.0
 
 flutter:


### PR DESCRIPTION
Bumps example app deps: envied 1.3.8, equatable 2.1.0, slang/slang_flutter/slang_build_runner 4.18.0, webview_flutter 4.14.1, envied_generator 1.3.8.