### PR TITLE
fix(example): use theme-aware colors for parameters panel across all features

### DIFF
--- a/app/example/lib/features/census_areas/presentation/widgets/census_areas_parameters_panel.dart
+++ b/app/example/lib/features/census_areas/presentation/widgets/census_areas_parameters_panel.dart
@@ -6,6 +6,7 @@ import 'package:stadata_example/core/generated/strings.g.dart';
 import 'package:stadata_example/features/census_areas/presentation/cubit/census_areas_cubit.dart';
 import 'package:stadata_example/shared/cubit/base_cubit.dart';
 import 'package:stadata_example/shared/widgets/error_widget.dart';
+import 'package:stadata_example/shared/widgets/parameters_panel.dart';
 import 'package:stadata_flutter_sdk/stadata_flutter_sdk.dart';
 
 class CensusAreasParametersPanel extends StatelessWidget {
@@ -19,41 +20,12 @@ class CensusAreasParametersPanel extends StatelessWidget {
       builder: (context, state) {
         final cubit = context.read<CensusAreasCubit>();
 
-        return Container(
-          width: double.infinity,
-          padding: const EdgeInsets.all(AppSizes.spaceMd),
-          decoration: BoxDecoration(
-            color: Colors.white,
-            borderRadius: BorderRadius.circular(8),
-            border: Border.all(
-              color: Theme.of(
-                context,
-              ).colorScheme.outline.withValues(alpha: 0.3),
-            ),
-          ),
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              Row(
-                children: [
-                  Icon(
-                    Icons.tune,
-                    size: 16,
-                    color: Theme.of(context).colorScheme.primary,
-                  ),
-                  const Gap(AppSizes.spaceXs),
-                  Text(
-                    t.censusAreas.parameters.title,
-                    style: Theme.of(context).textTheme.titleSmall?.copyWith(
-                      fontWeight: FontWeight.w600,
-                    ),
-                  ),
-                ],
-              ),
-              const Gap(AppSizes.spaceMd),
-              _CensusAreasParametersContent(state: state, cubit: cubit),
-            ],
-          ),
+        return ParametersPanel(
+          icon: Icons.tune,
+          title: t.censusAreas.parameters.title,
+          children: [
+            _CensusAreasParametersContent(state: state, cubit: cubit),
+          ],
         );
       },
     );
@@ -118,58 +90,49 @@ class _CensusAreasParametersForm extends StatelessWidget {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Text(
-              t.censusAreas.parameters.censusEvent,
-              style: Theme.of(
-                context,
-              ).textTheme.labelMedium?.copyWith(fontWeight: FontWeight.w500),
-            ),
-            const Gap(AppSizes.spaceXs),
-            DropdownButtonFormField<String>(
-              key: ValueKey(cubit.censusID),
-              initialValue: cubit.censusID,
-              isExpanded: true,
-              decoration: InputDecoration(
-                border: const OutlineInputBorder(),
-                hintText:
-                    isLoading && censusEvents.isEmpty
-                        ? 'Loading census events...'
-                        : t.censusAreas.parameters.censusEventHint,
-                isDense: true,
-                contentPadding: const EdgeInsets.symmetric(
-                  horizontal: AppSizes.spaceSm,
-                  vertical: AppSizes.spaceSm,
-                ),
+        ParameterField(
+          label: t.censusAreas.parameters.censusEvent,
+          child: DropdownButtonFormField<String>(
+            key: ValueKey(cubit.censusID),
+            initialValue: cubit.censusID,
+            isExpanded: true,
+            decoration: InputDecoration(
+              border: const OutlineInputBorder(),
+              hintText:
+                  isLoading && censusEvents.isEmpty
+                      ? 'Loading census events...'
+                      : t.censusAreas.parameters.censusEventHint,
+              isDense: true,
+              contentPadding: const EdgeInsets.symmetric(
+                horizontal: AppSizes.spaceSm,
+                vertical: AppSizes.spaceSm,
               ),
-              items:
-                  censusEvents.isEmpty
-                      ? [
-                        DropdownMenuItem<String>(
-                          enabled: false,
-                          child: Text(
-                            isLoading
-                                ? 'Loading...'
-                                : 'No census events available',
-                            overflow: TextOverflow.ellipsis,
-                          ),
-                        ),
-                      ]
-                      : censusEvents.map((event) {
-                        return DropdownMenuItem<String>(
-                          value: event.id,
-                          child: Text(
-                            '${event.id} - ${event.name}',
-                            overflow: TextOverflow.ellipsis,
-                          ),
-                        );
-                      }).toList(),
-              onChanged:
-                  isLoading && censusEvents.isEmpty ? null : cubit.setCensusID,
             ),
-          ],
+            items:
+                censusEvents.isEmpty
+                    ? [
+                      DropdownMenuItem<String>(
+                        enabled: false,
+                        child: Text(
+                          isLoading
+                              ? 'Loading...'
+                              : 'No census events available',
+                          overflow: TextOverflow.ellipsis,
+                        ),
+                      ),
+                    ]
+                    : censusEvents.map((event) {
+                      return DropdownMenuItem<String>(
+                        value: event.id,
+                        child: Text(
+                          '${event.id} - ${event.name}',
+                          overflow: TextOverflow.ellipsis,
+                        ),
+                      );
+                    }).toList(),
+            onChanged:
+                isLoading && censusEvents.isEmpty ? null : cubit.setCensusID,
+          ),
         ),
         const Gap(AppSizes.spaceMd),
         if (isLoadingAreas)

--- a/app/example/lib/features/census_data/presentation/widgets/census_data_parameters_panel.dart
+++ b/app/example/lib/features/census_data/presentation/widgets/census_data_parameters_panel.dart
@@ -7,6 +7,7 @@ import 'package:stadata_example/core/generated/strings.g.dart';
 import 'package:stadata_example/features/census_data/presentation/cubit/census_data_cubit.dart';
 import 'package:stadata_example/shared/cubit/base_cubit.dart';
 import 'package:stadata_example/shared/widgets/error_widget.dart';
+import 'package:stadata_example/shared/widgets/parameters_panel.dart';
 import 'package:stadata_flutter_sdk/stadata_flutter_sdk.dart';
 
 class CensusDataParametersPanel extends StatelessWidget {
@@ -20,41 +21,12 @@ class CensusDataParametersPanel extends StatelessWidget {
       builder: (context, state) {
         final cubit = context.read<CensusDataCubit>();
 
-        return Container(
-          width: double.infinity,
-          padding: const EdgeInsets.all(AppSizes.spaceMd),
-          decoration: BoxDecoration(
-            color: Colors.white,
-            borderRadius: BorderRadius.circular(8),
-            border: Border.all(
-              color: Theme.of(
-                context,
-              ).colorScheme.outline.withValues(alpha: 0.3),
-            ),
-          ),
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              Row(
-                children: [
-                  Icon(
-                    Icons.tune,
-                    size: 16,
-                    color: Theme.of(context).colorScheme.primary,
-                  ),
-                  const Gap(AppSizes.spaceXs),
-                  Text(
-                    t.censusData.parameters.title,
-                    style: Theme.of(context).textTheme.titleSmall?.copyWith(
-                      fontWeight: FontWeight.w600,
-                    ),
-                  ),
-                ],
-              ),
-              const Gap(AppSizes.spaceMd),
-              _CensusDataParametersContent(state: state, cubit: cubit),
-            ],
-          ),
+        return ParametersPanel(
+          icon: Icons.tune,
+          title: t.censusData.parameters.title,
+          children: [
+            _CensusDataParametersContent(state: state, cubit: cubit),
+          ],
         );
       },
     );
@@ -132,261 +104,225 @@ class _CensusDataForm extends StatelessWidget {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Text(
-              t.censusData.parameters.censusEvent,
-              style: Theme.of(
-                context,
-              ).textTheme.labelMedium?.copyWith(fontWeight: FontWeight.w500),
-            ),
-            const Gap(AppSizes.spaceXs),
-            DropdownButtonFormField<String>(
-              key: ValueKey(cubit.censusID),
-              initialValue: cubit.censusID,
-              isExpanded: true,
-              decoration: InputDecoration(
-                border: const OutlineInputBorder(),
-                hintText:
-                    isLoading && censusEvents.isEmpty
-                        ? 'Loading census events...'
-                        : t.censusData.parameters.censusEventHint,
-                isDense: true,
-                contentPadding: const EdgeInsets.symmetric(
-                  horizontal: AppSizes.spaceSm,
-                  vertical: AppSizes.spaceSm,
-                ),
+        ParameterField(
+          label: t.censusData.parameters.censusEvent,
+          child: DropdownButtonFormField<String>(
+            key: ValueKey(cubit.censusID),
+            initialValue: cubit.censusID,
+            isExpanded: true,
+            decoration: InputDecoration(
+              border: const OutlineInputBorder(),
+              hintText:
+                  isLoading && censusEvents.isEmpty
+                      ? 'Loading census events...'
+                      : t.censusData.parameters.censusEventHint,
+              isDense: true,
+              contentPadding: const EdgeInsets.symmetric(
+                horizontal: AppSizes.spaceSm,
+                vertical: AppSizes.spaceSm,
               ),
-              items:
-                  censusEvents.isEmpty
-                      ? [
-                        DropdownMenuItem<String>(
-                          enabled: false,
-                          child: Text(
-                            isLoading
-                                ? 'Loading...'
-                                : 'No census events available',
-                            overflow: TextOverflow.ellipsis,
-                          ),
-                        ),
-                      ]
-                      : censusEvents.map((event) {
-                        return DropdownMenuItem<String>(
-                          value: event.id,
-                          child: Text(
-                            '${event.id} - ${event.name}',
-                            overflow: TextOverflow.ellipsis,
-                          ),
-                        );
-                      }).toList(),
-              onChanged:
-                  isLoading && censusEvents.isEmpty ? null : cubit.setCensusID,
             ),
-          ],
-        ),
-        const Gap(AppSizes.spaceMd),
-        Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Text(
-              t.censusData.parameters.censusTopic,
-              style: Theme.of(
-                context,
-              ).textTheme.labelMedium?.copyWith(fontWeight: FontWeight.w500),
-            ),
-            const Gap(AppSizes.spaceXs),
-            DropdownButtonFormField<int>(
-              key: ValueKey('${cubit.censusID}_${cubit.topicID}'),
-              initialValue: cubit.topicID,
-              isExpanded: true,
-              decoration: InputDecoration(
-                border: const OutlineInputBorder(),
-                hintText:
-                    isLoadingTopicsAndAreas
-                        ? 'Loading census topics...'
-                        : !cubit.canLoadTopicsAndAreas
-                        ? 'Select census event first'
-                        : t.censusData.parameters.censusTopicHint,
-                isDense: true,
-                contentPadding: const EdgeInsets.symmetric(
-                  horizontal: AppSizes.spaceSm,
-                  vertical: AppSizes.spaceSm,
-                ),
-              ),
-              items:
-                  censusTopics.isEmpty
-                      ? [
-                        DropdownMenuItem<int>(
-                          enabled: false,
-                          child: Text(
-                            isLoadingTopicsAndAreas
-                                ? 'Loading...'
-                                : !cubit.canLoadTopicsAndAreas
-                                ? 'Select census event first'
-                                : 'No census topics available',
-                            overflow: TextOverflow.ellipsis,
-                          ),
-                        ),
-                      ]
-                      : censusTopics.map((topic) {
-                        return DropdownMenuItem<int>(
-                          value: topic.id,
-                          child: Text(
-                            '${topic.id} - ${topic.topic}',
-                            overflow: TextOverflow.ellipsis,
-                          ),
-                        );
-                      }).toList(),
-              onChanged:
-                  isLoadingTopicsAndAreas || !cubit.canLoadTopicsAndAreas
-                      ? null
-                      : cubit.setTopicID,
-            ),
-          ],
-        ),
-        const Gap(AppSizes.spaceMd),
-        Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Text(
-              t.censusData.parameters.censusArea,
-              style: Theme.of(
-                context,
-              ).textTheme.labelMedium?.copyWith(fontWeight: FontWeight.w500),
-            ),
-            const Gap(AppSizes.spaceXs),
-            SearchableDropdown<CensusArea>.paginated(
-              requestItemCount: 10,
-              hintText: Text(
-                cubit.canLoadTopicsAndAreas
-                    ? t.censusData.parameters.censusAreaHint
-                    : 'Select census event first',
-              ),
-              isEnabled: cubit.canLoadTopicsAndAreas,
-              paginatedRequest: (page, searchKey) async {
-                if (!cubit.canLoadTopicsAndAreas) {
-                  return [];
-                }
-                final areas = await cubit.fetchCensusAreas(
-                  page: page,
-                  searchText: searchKey,
-                );
-                return areas
-                    .map(
-                      (area) => SearchableDropdownMenuItem<CensusArea>(
-                        value: area,
-                        label: area.name,
-                        child: ListTile(
-                          contentPadding: EdgeInsets.zero,
-                          title: Text(
-                            area.name,
-                            style: Theme.of(context).textTheme.bodyMedium,
-                          ),
-                          subtitle: Text(
-                            'ID: ${area.id}',
-                            style: Theme.of(
-                              context,
-                            ).textTheme.bodySmall?.copyWith(
-                              color:
-                                  Theme.of(
-                                    context,
-                                  ).colorScheme.onSurfaceVariant,
-                            ),
-                          ),
+            items:
+                censusEvents.isEmpty
+                    ? [
+                      DropdownMenuItem<String>(
+                        enabled: false,
+                        child: Text(
+                          isLoading
+                              ? 'Loading...'
+                              : 'No census events available',
+                          overflow: TextOverflow.ellipsis,
                         ),
                       ),
-                    )
-                    .toList();
-              },
-              onChanged: (area) {
-                context.read<CensusDataCubit>().setCensusAreaID(
-                  area?.id.toString(),
-                );
-              },
-              backgroundDecoration:
-                  (child) => Card(
-                    margin: EdgeInsets.zero,
-                    elevation: 0,
-                    shape: RoundedRectangleBorder(
-                      borderRadius: BorderRadius.circular(8),
-                      side: BorderSide(
-                        color: Theme.of(context).colorScheme.outline,
+                    ]
+                    : censusEvents.map((event) {
+                      return DropdownMenuItem<String>(
+                        value: event.id,
+                        child: Text(
+                          '${event.id} - ${event.name}',
+                          overflow: TextOverflow.ellipsis,
+                        ),
+                      );
+                    }).toList(),
+            onChanged:
+                isLoading && censusEvents.isEmpty ? null : cubit.setCensusID,
+          ),
+        ),
+        const Gap(AppSizes.spaceMd),
+        ParameterField(
+          label: t.censusData.parameters.censusTopic,
+          child: DropdownButtonFormField<int>(
+            key: ValueKey('${cubit.censusID}_${cubit.topicID}'),
+            initialValue: cubit.topicID,
+            isExpanded: true,
+            decoration: InputDecoration(
+              border: const OutlineInputBorder(),
+              hintText:
+                  isLoadingTopicsAndAreas
+                      ? 'Loading census topics...'
+                      : !cubit.canLoadTopicsAndAreas
+                      ? 'Select census event first'
+                      : t.censusData.parameters.censusTopicHint,
+              isDense: true,
+              contentPadding: const EdgeInsets.symmetric(
+                horizontal: AppSizes.spaceSm,
+                vertical: AppSizes.spaceSm,
+              ),
+            ),
+            items:
+                censusTopics.isEmpty
+                    ? [
+                      DropdownMenuItem<int>(
+                        enabled: false,
+                        child: Text(
+                          isLoadingTopicsAndAreas
+                              ? 'Loading...'
+                              : !cubit.canLoadTopicsAndAreas
+                              ? 'Select census event first'
+                              : 'No census topics available',
+                          overflow: TextOverflow.ellipsis,
+                        ),
+                      ),
+                    ]
+                    : censusTopics.map((topic) {
+                      return DropdownMenuItem<int>(
+                        value: topic.id,
+                        child: Text(
+                          '${topic.id} - ${topic.topic}',
+                          overflow: TextOverflow.ellipsis,
+                        ),
+                      );
+                    }).toList(),
+            onChanged:
+                isLoadingTopicsAndAreas || !cubit.canLoadTopicsAndAreas
+                    ? null
+                    : cubit.setTopicID,
+          ),
+        ),
+        const Gap(AppSizes.spaceMd),
+        ParameterField(
+          label: t.censusData.parameters.censusArea,
+          child: SearchableDropdown<CensusArea>.paginated(
+            requestItemCount: 10,
+            hintText: Text(
+              cubit.canLoadTopicsAndAreas
+                  ? t.censusData.parameters.censusAreaHint
+                  : 'Select census event first',
+            ),
+            isEnabled: cubit.canLoadTopicsAndAreas,
+            paginatedRequest: (page, searchKey) async {
+              if (!cubit.canLoadTopicsAndAreas) {
+                return [];
+              }
+              final areas = await cubit.fetchCensusAreas(
+                page: page,
+                searchText: searchKey,
+              );
+              return areas
+                  .map(
+                    (area) => SearchableDropdownMenuItem<CensusArea>(
+                      value: area,
+                      label: area.name,
+                      child: ListTile(
+                        contentPadding: EdgeInsets.zero,
+                        title: Text(
+                          area.name,
+                          style: Theme.of(context).textTheme.bodyMedium,
+                        ),
+                        subtitle: Text(
+                          'ID: ${area.id}',
+                          style: Theme.of(
+                            context,
+                          ).textTheme.bodySmall?.copyWith(
+                            color:
+                                Theme.of(
+                                  context,
+                                ).colorScheme.onSurfaceVariant,
+                          ),
+                        ),
                       ),
                     ),
-                    child: Padding(
-                      padding: const EdgeInsets.symmetric(
-                        horizontal: AppSizes.spaceSm,
-                        vertical: AppSizes.spaceXs,
-                      ),
-                      child: child,
+                  )
+                  .toList();
+            },
+            onChanged: (area) {
+              context.read<CensusDataCubit>().setCensusAreaID(
+                area?.id.toString(),
+              );
+            },
+            backgroundDecoration:
+                (child) => Card(
+                  margin: EdgeInsets.zero,
+                  elevation: 0,
+                  shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(8),
+                    side: BorderSide(
+                      color: Theme.of(context).colorScheme.outline,
                     ),
                   ),
-              margin: EdgeInsets.zero,
-            ),
-          ],
+                  child: Padding(
+                    padding: const EdgeInsets.symmetric(
+                      horizontal: AppSizes.spaceSm,
+                      vertical: AppSizes.spaceXs,
+                    ),
+                    child: child,
+                  ),
+                ),
+            margin: EdgeInsets.zero,
+          ),
         ),
         const Gap(AppSizes.spaceMd),
-        Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Text(
-              t.censusData.parameters.dataset,
-              style: Theme.of(
-                context,
-              ).textTheme.labelMedium?.copyWith(fontWeight: FontWeight.w500),
+        ParameterField(
+          label: t.censusData.parameters.dataset,
+          child: DropdownButtonFormField<String>(
+            key: ValueKey(
+              '${cubit.censusID}_${cubit.topicID}_${cubit.datasetID}',
             ),
-            const Gap(AppSizes.spaceXs),
-            DropdownButtonFormField<String>(
-              key: ValueKey(
-                '${cubit.censusID}_${cubit.topicID}_${cubit.datasetID}',
+            initialValue: cubit.datasetID,
+            isExpanded: true,
+            decoration: InputDecoration(
+              border: const OutlineInputBorder(),
+              hintText:
+                  isLoadingDatasets
+                      ? 'Loading datasets...'
+                      : !cubit.canLoadDatasets
+                      ? 'Select topic first'
+                      : t.censusData.parameters.datasetHint,
+              isDense: true,
+              contentPadding: const EdgeInsets.symmetric(
+                horizontal: AppSizes.spaceSm,
+                vertical: AppSizes.spaceSm,
               ),
-              initialValue: cubit.datasetID,
-              isExpanded: true,
-              decoration: InputDecoration(
-                border: const OutlineInputBorder(),
-                hintText:
-                    isLoadingDatasets
-                        ? 'Loading datasets...'
-                        : !cubit.canLoadDatasets
-                        ? 'Select topic first'
-                        : t.censusData.parameters.datasetHint,
-                isDense: true,
-                contentPadding: const EdgeInsets.symmetric(
-                  horizontal: AppSizes.spaceSm,
-                  vertical: AppSizes.spaceSm,
-                ),
-              ),
-              items:
-                  censusDatasets.isEmpty
-                      ? [
-                        DropdownMenuItem<String>(
-                          enabled: false,
-                          child: Text(
-                            isLoadingDatasets
-                                ? 'Loading...'
-                                : !cubit.canLoadDatasets
-                                ? 'Select topic first'
-                                : 'No datasets available',
-                            overflow: TextOverflow.ellipsis,
-                          ),
+            ),
+            items:
+                censusDatasets.isEmpty
+                    ? [
+                      DropdownMenuItem<String>(
+                        enabled: false,
+                        child: Text(
+                          isLoadingDatasets
+                              ? 'Loading...'
+                              : !cubit.canLoadDatasets
+                              ? 'Select topic first'
+                              : 'No datasets available',
+                          overflow: TextOverflow.ellipsis,
                         ),
-                      ]
-                      : censusDatasets.map((dataset) {
-                        return DropdownMenuItem<String>(
-                          value: dataset.id.toString(),
-                          child: Text(
-                            '${dataset.id} - ${dataset.name}',
-                            overflow: TextOverflow.ellipsis,
-                          ),
-                        );
-                      }).toList(),
-              onChanged:
-                  isLoadingDatasets || !cubit.canLoadDatasets
-                      ? null
-                      : cubit.setDatasetID,
-            ),
-          ],
+                      ),
+                    ]
+                    : censusDatasets.map((dataset) {
+                      return DropdownMenuItem<String>(
+                        value: dataset.id.toString(),
+                        child: Text(
+                          '${dataset.id} - ${dataset.name}',
+                          overflow: TextOverflow.ellipsis,
+                        ),
+                      );
+                    }).toList(),
+            onChanged:
+                isLoadingDatasets || !cubit.canLoadDatasets
+                    ? null
+                    : cubit.setDatasetID,
+          ),
         ),
       ],
     );

--- a/app/example/lib/features/census_datasets/presentation/widgets/census_datasets_parameters_panel.dart
+++ b/app/example/lib/features/census_datasets/presentation/widgets/census_datasets_parameters_panel.dart
@@ -6,6 +6,7 @@ import 'package:stadata_example/core/generated/strings.g.dart';
 import 'package:stadata_example/features/census_datasets/presentation/cubit/census_datasets_cubit.dart';
 import 'package:stadata_example/shared/cubit/base_cubit.dart';
 import 'package:stadata_example/shared/widgets/error_widget.dart';
+import 'package:stadata_example/shared/widgets/parameters_panel.dart';
 import 'package:stadata_flutter_sdk/stadata_flutter_sdk.dart';
 
 class CensusDatasetsParametersPanel extends StatelessWidget {
@@ -19,41 +20,12 @@ class CensusDatasetsParametersPanel extends StatelessWidget {
       builder: (context, state) {
         final cubit = context.read<CensusDatasetsCubit>();
 
-        return Container(
-          width: double.infinity,
-          padding: const EdgeInsets.all(AppSizes.spaceMd),
-          decoration: BoxDecoration(
-            color: Colors.white,
-            borderRadius: BorderRadius.circular(8),
-            border: Border.all(
-              color: Theme.of(
-                context,
-              ).colorScheme.outline.withValues(alpha: 0.3),
-            ),
-          ),
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              Row(
-                children: [
-                  Icon(
-                    Icons.tune,
-                    size: 16,
-                    color: Theme.of(context).colorScheme.primary,
-                  ),
-                  const Gap(AppSizes.spaceXs),
-                  Text(
-                    t.censusDatasets.parameters.title,
-                    style: Theme.of(context).textTheme.titleSmall?.copyWith(
-                      fontWeight: FontWeight.w600,
-                    ),
-                  ),
-                ],
-              ),
-              const Gap(AppSizes.spaceMd),
-              _CensusDatasetsParametersContent(state: state, cubit: cubit),
-            ],
-          ),
+        return ParametersPanel(
+          icon: Icons.tune,
+          title: t.censusDatasets.parameters.title,
+          children: [
+            _CensusDatasetsParametersContent(state: state, cubit: cubit),
+          ],
         );
       },
     );
@@ -124,118 +96,100 @@ class _CensusDatasetsParametersForm extends StatelessWidget {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Text(
-              t.censusDatasets.parameters.censusEvent,
-              style: Theme.of(
-                context,
-              ).textTheme.labelMedium?.copyWith(fontWeight: FontWeight.w500),
-            ),
-            const Gap(AppSizes.spaceXs),
-            DropdownButtonFormField<String>(
-              key: ValueKey(cubit.censusID),
-              initialValue: cubit.censusID,
-              isExpanded: true,
-              decoration: InputDecoration(
-                border: const OutlineInputBorder(),
-                hintText:
-                    isLoading && censusEvents.isEmpty
-                        ? 'Loading census events...'
-                        : t.censusDatasets.parameters.censusEventHint,
-                isDense: true,
-                contentPadding: const EdgeInsets.symmetric(
-                  horizontal: AppSizes.spaceSm,
-                  vertical: AppSizes.spaceSm,
-                ),
+        ParameterField(
+          label: t.censusDatasets.parameters.censusEvent,
+          child: DropdownButtonFormField<String>(
+            key: ValueKey(cubit.censusID),
+            initialValue: cubit.censusID,
+            isExpanded: true,
+            decoration: InputDecoration(
+              border: const OutlineInputBorder(),
+              hintText:
+                  isLoading && censusEvents.isEmpty
+                      ? 'Loading census events...'
+                      : t.censusDatasets.parameters.censusEventHint,
+              isDense: true,
+              contentPadding: const EdgeInsets.symmetric(
+                horizontal: AppSizes.spaceSm,
+                vertical: AppSizes.spaceSm,
               ),
-              items:
-                  censusEvents.isEmpty
-                      ? [
-                        DropdownMenuItem<String>(
-                          enabled: false,
-                          child: Text(
-                            isLoading
-                                ? 'Loading...'
-                                : 'No census events available',
-                            overflow: TextOverflow.ellipsis,
-                          ),
-                        ),
-                      ]
-                      : censusEvents.map((event) {
-                        return DropdownMenuItem<String>(
-                          value: event.id,
-                          child: Text(
-                            '${event.id} - ${event.name}',
-                            overflow: TextOverflow.ellipsis,
-                          ),
-                        );
-                      }).toList(),
-              onChanged:
-                  isLoading && censusEvents.isEmpty ? null : cubit.setCensusID,
             ),
-          ],
+            items:
+                censusEvents.isEmpty
+                    ? [
+                      DropdownMenuItem<String>(
+                        enabled: false,
+                        child: Text(
+                          isLoading
+                              ? 'Loading...'
+                              : 'No census events available',
+                          overflow: TextOverflow.ellipsis,
+                        ),
+                      ),
+                    ]
+                    : censusEvents.map((event) {
+                      return DropdownMenuItem<String>(
+                        value: event.id,
+                        child: Text(
+                          '${event.id} - ${event.name}',
+                          overflow: TextOverflow.ellipsis,
+                        ),
+                      );
+                    }).toList(),
+            onChanged:
+                isLoading && censusEvents.isEmpty ? null : cubit.setCensusID,
+          ),
         ),
         const Gap(AppSizes.spaceMd),
-        Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Text(
-              t.censusDatasets.parameters.censusTopic,
-              style: Theme.of(
-                context,
-              ).textTheme.labelMedium?.copyWith(fontWeight: FontWeight.w500),
-            ),
-            const Gap(AppSizes.spaceXs),
-            DropdownButtonFormField<int>(
-              key: ValueKey('${cubit.censusID}_${cubit.topicID}'),
-              initialValue: cubit.topicID,
-              isExpanded: true,
-              decoration: InputDecoration(
-                border: const OutlineInputBorder(),
-                hintText:
-                    isLoadingTopics
-                        ? 'Loading census topics...'
-                        : !cubit.canLoadTopics
-                        ? 'Select census event first'
-                        : t.censusDatasets.parameters.censusTopicHint,
-                isDense: true,
-                contentPadding: const EdgeInsets.symmetric(
-                  horizontal: AppSizes.spaceSm,
-                  vertical: AppSizes.spaceSm,
-                ),
+        ParameterField(
+          label: t.censusDatasets.parameters.censusTopic,
+          child: DropdownButtonFormField<int>(
+            key: ValueKey('${cubit.censusID}_${cubit.topicID}'),
+            initialValue: cubit.topicID,
+            isExpanded: true,
+            decoration: InputDecoration(
+              border: const OutlineInputBorder(),
+              hintText:
+                  isLoadingTopics
+                      ? 'Loading census topics...'
+                      : !cubit.canLoadTopics
+                      ? 'Select census event first'
+                      : t.censusDatasets.parameters.censusTopicHint,
+              isDense: true,
+              contentPadding: const EdgeInsets.symmetric(
+                horizontal: AppSizes.spaceSm,
+                vertical: AppSizes.spaceSm,
               ),
-              items:
-                  censusTopics.isEmpty
-                      ? [
-                        DropdownMenuItem<int>(
-                          enabled: false,
-                          child: Text(
-                            isLoadingTopics
-                                ? 'Loading...'
-                                : !cubit.canLoadTopics
-                                ? 'Select census event first'
-                                : 'No census topics available',
-                            overflow: TextOverflow.ellipsis,
-                          ),
-                        ),
-                      ]
-                      : censusTopics.map((topic) {
-                        return DropdownMenuItem<int>(
-                          value: topic.id,
-                          child: Text(
-                            '${topic.id} - ${topic.topic}',
-                            overflow: TextOverflow.ellipsis,
-                          ),
-                        );
-                      }).toList(),
-              onChanged:
-                  isLoadingTopics || !cubit.canLoadTopics
-                      ? null
-                      : cubit.setTopicID,
             ),
-          ],
+            items:
+                censusTopics.isEmpty
+                    ? [
+                      DropdownMenuItem<int>(
+                        enabled: false,
+                        child: Text(
+                          isLoadingTopics
+                              ? 'Loading...'
+                              : !cubit.canLoadTopics
+                              ? 'Select census event first'
+                              : 'No census topics available',
+                          overflow: TextOverflow.ellipsis,
+                        ),
+                      ),
+                    ]
+                    : censusTopics.map((topic) {
+                      return DropdownMenuItem<int>(
+                        value: topic.id,
+                        child: Text(
+                          '${topic.id} - ${topic.topic}',
+                          overflow: TextOverflow.ellipsis,
+                        ),
+                      );
+                    }).toList(),
+            onChanged:
+                isLoadingTopics || !cubit.canLoadTopics
+                    ? null
+                    : cubit.setTopicID,
+          ),
         ),
       ],
     );

--- a/app/example/lib/features/census_topics/presentation/widgets/census_topics_parameters_panel.dart
+++ b/app/example/lib/features/census_topics/presentation/widgets/census_topics_parameters_panel.dart
@@ -1,11 +1,11 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:gap/gap.dart';
 import 'package:stadata_example/core/constants/app_sizes.dart';
 import 'package:stadata_example/core/generated/strings.g.dart';
 import 'package:stadata_example/features/census_topics/presentation/cubit/census_topics_cubit.dart';
 import 'package:stadata_example/shared/cubit/base_cubit.dart';
 import 'package:stadata_example/shared/widgets/error_widget.dart';
+import 'package:stadata_example/shared/widgets/parameters_panel.dart';
 import 'package:stadata_flutter_sdk/stadata_flutter_sdk.dart';
 
 class CensusTopicsParametersPanel extends StatelessWidget {
@@ -19,41 +19,12 @@ class CensusTopicsParametersPanel extends StatelessWidget {
       builder: (context, state) {
         final cubit = context.read<CensusTopicsCubit>();
 
-        return Container(
-          width: double.infinity,
-          padding: const EdgeInsets.all(AppSizes.spaceMd),
-          decoration: BoxDecoration(
-            color: Colors.white,
-            borderRadius: BorderRadius.circular(8),
-            border: Border.all(
-              color: Theme.of(
-                context,
-              ).colorScheme.outline.withValues(alpha: 0.3),
-            ),
-          ),
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              Row(
-                children: [
-                  Icon(
-                    Icons.tune,
-                    size: 16,
-                    color: Theme.of(context).colorScheme.primary,
-                  ),
-                  const Gap(AppSizes.spaceXs),
-                  Text(
-                    t.censusTopics.parameters.title,
-                    style: Theme.of(context).textTheme.titleSmall?.copyWith(
-                      fontWeight: FontWeight.w600,
-                    ),
-                  ),
-                ],
-              ),
-              const Gap(AppSizes.spaceMd),
-              _CensusTopicsParametersContent(state: state, cubit: cubit),
-            ],
-          ),
+        return ParametersPanel(
+          icon: Icons.tune,
+          title: t.censusTopics.parameters.title,
+          children: [
+            _CensusTopicsParametersContent(state: state, cubit: cubit),
+          ],
         );
       },
     );
@@ -117,56 +88,47 @@ class _CensusTopicsParametersForm extends StatelessWidget {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Text(
-              t.censusTopics.parameters.censusEvent,
-              style: Theme.of(
-                context,
-              ).textTheme.labelMedium?.copyWith(fontWeight: FontWeight.w500),
-            ),
-            const Gap(AppSizes.spaceXs),
-            DropdownButtonFormField<String>(
-              initialValue: cubit.censusID,
-              isExpanded: true,
-              decoration: InputDecoration(
-                border: const OutlineInputBorder(),
-                hintText:
-                    isLoading
-                        ? 'Loading census events...'
-                        : t.censusTopics.parameters.censusEventHint,
-                isDense: true,
-                contentPadding: const EdgeInsets.symmetric(
-                  horizontal: AppSizes.spaceSm,
-                  vertical: AppSizes.spaceSm,
-                ),
+        ParameterField(
+          label: t.censusTopics.parameters.censusEvent,
+          child: DropdownButtonFormField<String>(
+            initialValue: cubit.censusID,
+            isExpanded: true,
+            decoration: InputDecoration(
+              border: const OutlineInputBorder(),
+              hintText:
+                  isLoading
+                      ? 'Loading census events...'
+                      : t.censusTopics.parameters.censusEventHint,
+              isDense: true,
+              contentPadding: const EdgeInsets.symmetric(
+                horizontal: AppSizes.spaceSm,
+                vertical: AppSizes.spaceSm,
               ),
-              items:
-                  censusEvents.isEmpty
-                      ? [
-                        DropdownMenuItem<String>(
-                          enabled: false,
-                          child: Text(
-                            isLoading
-                                ? 'Loading...'
-                                : 'No census events available',
-                            overflow: TextOverflow.ellipsis,
-                          ),
-                        ),
-                      ]
-                      : censusEvents.map((event) {
-                        return DropdownMenuItem<String>(
-                          value: event.id,
-                          child: Text(
-                            '${event.id} - ${event.name}',
-                            overflow: TextOverflow.ellipsis,
-                          ),
-                        );
-                      }).toList(),
-              onChanged: isLoading ? null : cubit.setCensusID,
             ),
-          ],
+            items:
+                censusEvents.isEmpty
+                    ? [
+                      DropdownMenuItem<String>(
+                        enabled: false,
+                        child: Text(
+                          isLoading
+                              ? 'Loading...'
+                              : 'No census events available',
+                          overflow: TextOverflow.ellipsis,
+                        ),
+                      ),
+                    ]
+                    : censusEvents.map((event) {
+                      return DropdownMenuItem<String>(
+                        value: event.id,
+                        child: Text(
+                          '${event.id} - ${event.name}',
+                          overflow: TextOverflow.ellipsis,
+                        ),
+                      );
+                    }).toList(),
+            onChanged: isLoading ? null : cubit.setCensusID,
+          ),
         ),
       ],
     );

--- a/app/example/lib/features/derived_periods/presentation/widgets/derived_periods_parameters_panel.dart
+++ b/app/example/lib/features/derived_periods/presentation/widgets/derived_periods_parameters_panel.dart
@@ -6,6 +6,7 @@ import 'package:searchable_paginated_dropdown/searchable_paginated_dropdown.dart
 import 'package:stadata_example/core/constants/app_sizes.dart';
 import 'package:stadata_example/core/generated/strings.g.dart';
 import 'package:stadata_example/features/derived_periods/presentation/cubit/derived_periods_cubit.dart';
+import 'package:stadata_example/shared/widgets/parameters_panel.dart';
 import 'package:stadata_flutter_sdk/stadata_flutter_sdk.dart';
 
 class DerivedPeriodsParametersPanel extends StatefulWidget {
@@ -38,181 +39,127 @@ class _DerivedPeriodsParametersPanelState
     final t = Translations.of(context);
     final cubit = context.read<DerivedPeriodsCubit>();
 
-    return Container(
-      width: double.infinity,
-      padding: const EdgeInsets.all(AppSizes.spaceMd),
-      decoration: BoxDecoration(
-        color: Colors.white,
-        borderRadius: BorderRadius.circular(8),
-        border: Border.all(
-          color: Theme.of(context).colorScheme.outline.withValues(alpha: 0.3),
+    return ParametersPanel(
+      icon: Icons.tune,
+      title: 'Parameters',
+      children: [
+        // Domain field
+        ParameterField(
+          label: 'Domain *',
+          child: TextFormField(
+            controller: _domainController,
+            decoration: const InputDecoration(
+              border: OutlineInputBorder(),
+              hintText: 'e.g., 7200 (4 digits)',
+              isDense: true,
+              contentPadding: EdgeInsets.symmetric(
+                horizontal: AppSizes.spaceSm,
+                vertical: AppSizes.spaceSm,
+              ),
+            ),
+            keyboardType: TextInputType.number,
+            inputFormatters: [FilteringTextInputFormatter.digitsOnly],
+            maxLength: 4,
+            onChanged: cubit.setDomain,
+          ),
         ),
-      ),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Row(
-            children: [
-              Icon(
-                Icons.tune,
-                size: 16,
-                color: Theme.of(context).colorScheme.primary,
+        const Gap(AppSizes.spaceMd),
+        // Language dropdown
+        ParameterField(
+          label: 'Language',
+          child: DropdownButtonFormField<DataLanguage>(
+            initialValue: cubit.currentLanguage,
+            decoration: const InputDecoration(
+              border: OutlineInputBorder(),
+              isDense: true,
+              contentPadding: EdgeInsets.symmetric(
+                horizontal: AppSizes.spaceSm,
+                vertical: AppSizes.spaceSm,
               ),
-              const Gap(AppSizes.spaceXs),
-              Text(
-                'Parameters',
-                style: Theme.of(
-                  context,
-                ).textTheme.titleSmall?.copyWith(fontWeight: FontWeight.w600),
-              ),
-            ],
-          ),
-          const Gap(AppSizes.spaceMd),
-          // Domain field
-          Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              Text(
-                'Domain *',
-                style: Theme.of(
-                  context,
-                ).textTheme.labelMedium?.copyWith(fontWeight: FontWeight.w500),
-              ),
-              const Gap(AppSizes.spaceXs),
-              TextFormField(
-                controller: _domainController,
-                decoration: const InputDecoration(
-                  border: OutlineInputBorder(),
-                  hintText: 'e.g., 7200 (4 digits)',
-                  isDense: true,
-                  contentPadding: EdgeInsets.symmetric(
-                    horizontal: AppSizes.spaceSm,
-                    vertical: AppSizes.spaceSm,
-                  ),
-                ),
-                keyboardType: TextInputType.number,
-                inputFormatters: [FilteringTextInputFormatter.digitsOnly],
-                maxLength: 4,
-                onChanged: cubit.setDomain,
-              ),
-            ],
-          ),
-          const Gap(AppSizes.spaceMd),
-          // Language dropdown
-          Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              Text(
-                'Language',
-                style: Theme.of(
-                  context,
-                ).textTheme.labelMedium?.copyWith(fontWeight: FontWeight.w500),
-              ),
-              const Gap(AppSizes.spaceXs),
-              DropdownButtonFormField<DataLanguage>(
-                initialValue: cubit.currentLanguage,
-                decoration: const InputDecoration(
-                  border: OutlineInputBorder(),
-                  isDense: true,
-                  contentPadding: EdgeInsets.symmetric(
-                    horizontal: AppSizes.spaceSm,
-                    vertical: AppSizes.spaceSm,
-                  ),
-                ),
-                items:
-                    DataLanguage.values.map((lang) {
-                      return DropdownMenuItem(
-                        value: lang,
-                        child: Text(
-                          lang == DataLanguage.id
-                              ? t.instructions.languageLabels.indonesian
-                              : t.instructions.languageLabels.english,
-                        ),
-                      );
-                    }).toList(),
-                onChanged: (value) {
-                  if (value != null) {
-                    cubit.changeLanguage(value);
-                  }
-                },
-              ),
-            ],
-          ),
-          const Gap(AppSizes.spaceMd),
-          // Variable dropdown (optional, paginated)
-          Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              Text(
-                'Variable ID (Optional)',
-                style: Theme.of(
-                  context,
-                ).textTheme.labelMedium?.copyWith(fontWeight: FontWeight.w500),
-              ),
-              const Gap(AppSizes.spaceXs),
-              SearchableDropdown<Variable>.paginated(
-                requestItemCount: 10,
-                hintText: Text(
-                  cubit.canLoadData
-                      ? 'Select a variable (optional)'
-                      : 'Enter domain first (4 digits)',
-                ),
-                isEnabled: cubit.canLoadData,
-                paginatedRequest: (page, searchKey) async {
-                  if (!cubit.canLoadData) {
-                    return [];
-                  }
-                  final variables = await cubit.fetchVariables(
-                    page: page,
-                    searchText: searchKey,
+            ),
+            items:
+                DataLanguage.values.map((lang) {
+                  return DropdownMenuItem(
+                    value: lang,
+                    child: Text(
+                      lang == DataLanguage.id
+                          ? t.instructions.languageLabels.indonesian
+                          : t.instructions.languageLabels.english,
+                    ),
                   );
-                  return variables
-                      .map(
-                        (variable) => SearchableDropdownMenuItem<Variable>(
-                          value: variable,
-                          label: variable.title,
-                          child: ListTile(
-                            contentPadding: EdgeInsets.zero,
-                            title: Text(
-                              variable.title,
-                              style: Theme.of(context).textTheme.bodyMedium,
-                            ),
-                            subtitle: Text(
-                              variable.subjectName,
-                              style: Theme.of(
-                                context,
-                              ).textTheme.bodySmall?.copyWith(
-                                color:
-                                    Theme.of(
-                                      context,
-                                    ).colorScheme.onSurfaceVariant,
-                              ),
-                            ),
+                }).toList(),
+            onChanged: (value) {
+              if (value != null) {
+                cubit.changeLanguage(value);
+              }
+            },
+          ),
+        ),
+        const Gap(AppSizes.spaceMd),
+        // Variable dropdown (optional, paginated)
+        ParameterField(
+          label: 'Variable ID (Optional)',
+          child: SearchableDropdown<Variable>.paginated(
+            requestItemCount: 10,
+            hintText: Text(
+              cubit.canLoadData
+                  ? 'Select a variable (optional)'
+                  : 'Enter domain first (4 digits)',
+            ),
+            isEnabled: cubit.canLoadData,
+            paginatedRequest: (page, searchKey) async {
+              if (!cubit.canLoadData) {
+                return [];
+              }
+              final variables = await cubit.fetchVariables(
+                page: page,
+                searchText: searchKey,
+              );
+              return variables
+                  .map(
+                    (variable) => SearchableDropdownMenuItem<Variable>(
+                      value: variable,
+                      label: variable.title,
+                      child: ListTile(
+                        contentPadding: EdgeInsets.zero,
+                        title: Text(
+                          variable.title,
+                          style: Theme.of(context).textTheme.bodyMedium,
+                        ),
+                        subtitle: Text(
+                          variable.subjectName,
+                          style: Theme.of(
+                            context,
+                          ).textTheme.bodySmall?.copyWith(
+                            color:
+                                Theme.of(
+                                  context,
+                                ).colorScheme.onSurfaceVariant,
                           ),
                         ),
-                      )
-                      .toList();
-                },
-                onChanged: (variable) {
-                  cubit.setVariableID(variable?.id);
-                },
-                backgroundDecoration:
-                    (child) => Card(
-                      margin: EdgeInsets.zero,
-                      elevation: 0,
-                      shape: RoundedRectangleBorder(
-                        borderRadius: BorderRadius.circular(8),
-                        side: BorderSide(
-                          color: Theme.of(context).colorScheme.outline,
-                        ),
                       ),
-                      child: child,
                     ),
-              ),
-            ],
+                  )
+                  .toList();
+            },
+            onChanged: (variable) {
+              cubit.setVariableID(variable?.id);
+            },
+            backgroundDecoration:
+                (child) => Card(
+                  margin: EdgeInsets.zero,
+                  elevation: 0,
+                  shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(8),
+                    side: BorderSide(
+                      color: Theme.of(context).colorScheme.outline,
+                    ),
+                  ),
+                  child: child,
+                ),
           ),
-        ],
-      ),
+        ),
+      ],
     );
   }
 }

--- a/app/example/lib/features/derived_variables/presentation/widgets/derived_variables_parameters_panel.dart
+++ b/app/example/lib/features/derived_variables/presentation/widgets/derived_variables_parameters_panel.dart
@@ -6,6 +6,7 @@ import 'package:searchable_paginated_dropdown/searchable_paginated_dropdown.dart
 import 'package:stadata_example/core/constants/app_sizes.dart';
 import 'package:stadata_example/core/generated/strings.g.dart';
 import 'package:stadata_example/features/derived_variables/presentation/cubit/derived_variables_cubit.dart';
+import 'package:stadata_example/shared/widgets/parameters_panel.dart';
 import 'package:stadata_flutter_sdk/stadata_flutter_sdk.dart';
 
 class DerivedVariablesParametersPanel extends StatefulWidget {
@@ -38,147 +39,160 @@ class _DerivedVariablesParametersPanelState
     final t = Translations.of(context);
     final cubit = context.read<DerivedVariablesCubit>();
 
-    return Container(
-      width: double.infinity,
-      padding: const EdgeInsets.all(AppSizes.spaceMd),
-      decoration: BoxDecoration(
-        color: Colors.white,
-        borderRadius: BorderRadius.circular(8),
-        border: Border.all(
-          color: Theme.of(context).colorScheme.outline.withValues(alpha: 0.3),
+    return ParametersPanel(
+      icon: Icons.tune,
+      title: 'Parameters',
+      children: [
+        // Domain field
+        ParameterField(
+          label: 'Domain *',
+          child: TextFormField(
+            controller: _domainController,
+            decoration: const InputDecoration(
+              border: OutlineInputBorder(),
+              hintText: 'e.g., 7200 (4 digits)',
+              isDense: true,
+              contentPadding: EdgeInsets.symmetric(
+                horizontal: AppSizes.spaceSm,
+                vertical: AppSizes.spaceSm,
+              ),
+            ),
+            keyboardType: TextInputType.number,
+            inputFormatters: [FilteringTextInputFormatter.digitsOnly],
+            maxLength: 4,
+            onChanged: cubit.setDomain,
+          ),
         ),
-      ),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Row(
-            children: [
-              Icon(
-                Icons.tune,
-                size: 16,
-                color: Theme.of(context).colorScheme.primary,
+        const Gap(AppSizes.spaceMd),
+        // Language dropdown
+        ParameterField(
+          label: 'Language',
+          child: DropdownButtonFormField<DataLanguage>(
+            initialValue: cubit.currentLanguage,
+            decoration: const InputDecoration(
+              border: OutlineInputBorder(),
+              isDense: true,
+              contentPadding: EdgeInsets.symmetric(
+                horizontal: AppSizes.spaceSm,
+                vertical: AppSizes.spaceSm,
               ),
-              const Gap(AppSizes.spaceXs),
-              Text(
-                'Parameters',
-                style: Theme.of(
-                  context,
-                ).textTheme.titleSmall?.copyWith(fontWeight: FontWeight.w600),
-              ),
-            ],
-          ),
-          const Gap(AppSizes.spaceMd),
-          // Domain field
-          Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              Text(
-                'Domain *',
-                style: Theme.of(
-                  context,
-                ).textTheme.labelMedium?.copyWith(fontWeight: FontWeight.w500),
-              ),
-              const Gap(AppSizes.spaceXs),
-              TextFormField(
-                controller: _domainController,
-                decoration: const InputDecoration(
-                  border: OutlineInputBorder(),
-                  hintText: 'e.g., 7200 (4 digits)',
-                  isDense: true,
-                  contentPadding: EdgeInsets.symmetric(
-                    horizontal: AppSizes.spaceSm,
-                    vertical: AppSizes.spaceSm,
-                  ),
-                ),
-                keyboardType: TextInputType.number,
-                inputFormatters: [FilteringTextInputFormatter.digitsOnly],
-                maxLength: 4,
-                onChanged: cubit.setDomain,
-              ),
-            ],
-          ),
-          const Gap(AppSizes.spaceMd),
-          // Language dropdown
-          Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              Text(
-                'Language',
-                style: Theme.of(
-                  context,
-                ).textTheme.labelMedium?.copyWith(fontWeight: FontWeight.w500),
-              ),
-              const Gap(AppSizes.spaceXs),
-              DropdownButtonFormField<DataLanguage>(
-                initialValue: cubit.currentLanguage,
-                decoration: const InputDecoration(
-                  border: OutlineInputBorder(),
-                  isDense: true,
-                  contentPadding: EdgeInsets.symmetric(
-                    horizontal: AppSizes.spaceSm,
-                    vertical: AppSizes.spaceSm,
-                  ),
-                ),
-                items:
-                    DataLanguage.values.map((lang) {
-                      return DropdownMenuItem(
-                        value: lang,
-                        child: Text(
-                          lang == DataLanguage.id
-                              ? t.instructions.languageLabels.indonesian
-                              : t.instructions.languageLabels.english,
-                        ),
-                      );
-                    }).toList(),
-                onChanged: (value) {
-                  if (value != null) {
-                    cubit.changeLanguage(value);
-                  }
-                },
-              ),
-            ],
-          ),
-          const Gap(AppSizes.spaceMd),
-          // Variable dropdown (optional, paginated)
-          Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              Text(
-                'Variable ID (Optional)',
-                style: Theme.of(
-                  context,
-                ).textTheme.labelMedium?.copyWith(fontWeight: FontWeight.w500),
-              ),
-              const Gap(AppSizes.spaceXs),
-              SearchableDropdown<Variable>.paginated(
-                requestItemCount: 10,
-                hintText: Text(
-                  cubit.canLoadData
-                      ? 'Select a variable (optional)'
-                      : 'Enter domain first (4 digits)',
-                ),
-                isEnabled: cubit.canLoadData,
-                paginatedRequest: (page, searchKey) async {
-                  if (!cubit.canLoadData) {
-                    return [];
-                  }
-                  final variables = await cubit.fetchVariables(
-                    page: page,
-                    searchText: searchKey,
+            ),
+            items:
+                DataLanguage.values.map((lang) {
+                  return DropdownMenuItem(
+                    value: lang,
+                    child: Text(
+                      lang == DataLanguage.id
+                          ? t.instructions.languageLabels.indonesian
+                          : t.instructions.languageLabels.english,
+                    ),
                   );
-                  return variables
-                      .map(
-                        (variable) => SearchableDropdownMenuItem<Variable>(
-                          value: variable,
-                          label: variable.title,
+                }).toList(),
+            onChanged: (value) {
+              if (value != null) {
+                cubit.changeLanguage(value);
+              }
+            },
+          ),
+        ),
+        const Gap(AppSizes.spaceMd),
+        // Variable dropdown (optional, paginated)
+        ParameterField(
+          label: 'Variable ID (Optional)',
+          child: SearchableDropdown<Variable>.paginated(
+            requestItemCount: 10,
+            hintText: Text(
+              cubit.canLoadData
+                  ? 'Select a variable (optional)'
+                  : 'Enter domain first (4 digits)',
+            ),
+            isEnabled: cubit.canLoadData,
+            paginatedRequest: (page, searchKey) async {
+              if (!cubit.canLoadData) {
+                return [];
+              }
+              final variables = await cubit.fetchVariables(
+                page: page,
+                searchText: searchKey,
+              );
+              return variables
+                  .map(
+                    (variable) => SearchableDropdownMenuItem<Variable>(
+                      value: variable,
+                      label: variable.title,
+                      child: ListTile(
+                        contentPadding: EdgeInsets.zero,
+                        title: Text(
+                          variable.title,
+                          style: Theme.of(context).textTheme.bodyMedium,
+                        ),
+                        subtitle: Text(
+                          variable.subjectName,
+                          style: Theme.of(
+                            context,
+                          ).textTheme.bodySmall?.copyWith(
+                            color:
+                                Theme.of(
+                                  context,
+                                ).colorScheme.onSurfaceVariant,
+                          ),
+                        ),
+                      ),
+                    ),
+                  )
+                  .toList();
+            },
+            onChanged: (variable) {
+              cubit.setVariableID(variable?.id);
+            },
+            backgroundDecoration:
+                (child) => Card(
+                  margin: EdgeInsets.zero,
+                  elevation: 0,
+                  shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(8),
+                    side: BorderSide(
+                      color: Theme.of(context).colorScheme.outline,
+                    ),
+                  ),
+                  child: child,
+                ),
+          ),
+        ),
+        const Gap(AppSizes.spaceMd),
+        // Vertical Variable dropdown (optional, paginated)
+        ParameterField(
+          label: 'Vertical Group (Optional)',
+          child: SearchableDropdown<VerticalVariable>.paginated(
+            requestItemCount: 10,
+            hintText: Text(
+              cubit.canLoadData
+                  ? 'Select a vertical variable (optional)'
+                  : 'Enter domain first (4 digits)',
+            ),
+            isEnabled: cubit.canLoadData,
+            paginatedRequest: (page, searchKey) async {
+              if (!cubit.canLoadData) {
+                return [];
+              }
+              final verticalVariables = await cubit.fetchVerticalVariables(
+                page: page,
+                searchText: searchKey,
+              );
+              return verticalVariables
+                  .map(
+                    (verticalVariable) =>
+                        SearchableDropdownMenuItem<VerticalVariable>(
+                          value: verticalVariable,
+                          label: verticalVariable.title,
                           child: ListTile(
                             contentPadding: EdgeInsets.zero,
                             title: Text(
-                              variable.title,
+                              verticalVariable.title,
                               style: Theme.of(context).textTheme.bodyMedium,
                             ),
                             subtitle: Text(
-                              variable.subjectName,
+                              verticalVariable.groupName ?? '',
                               style: Theme.of(
                                 context,
                               ).textTheme.bodySmall?.copyWith(
@@ -190,103 +204,27 @@ class _DerivedVariablesParametersPanelState
                             ),
                           ),
                         ),
-                      )
-                      .toList();
-                },
-                onChanged: (variable) {
-                  cubit.setVariableID(variable?.id);
-                },
-                backgroundDecoration:
-                    (child) => Card(
-                      margin: EdgeInsets.zero,
-                      elevation: 0,
-                      shape: RoundedRectangleBorder(
-                        borderRadius: BorderRadius.circular(8),
-                        side: BorderSide(
-                          color: Theme.of(context).colorScheme.outline,
-                        ),
-                      ),
-                      child: child,
+                  )
+                  .toList();
+            },
+            onChanged: (verticalVariable) {
+              cubit.setVerticalGroup(verticalVariable?.id);
+            },
+            backgroundDecoration:
+                (child) => Card(
+                  margin: EdgeInsets.zero,
+                  elevation: 0,
+                  shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(8),
+                    side: BorderSide(
+                      color: Theme.of(context).colorScheme.outline,
                     ),
-              ),
-            ],
-          ),
-          const Gap(AppSizes.spaceMd),
-          // Vertical Variable dropdown (optional, paginated)
-          Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              Text(
-                'Vertical Group (Optional)',
-                style: Theme.of(
-                  context,
-                ).textTheme.labelMedium?.copyWith(fontWeight: FontWeight.w500),
-              ),
-              const Gap(AppSizes.spaceXs),
-              SearchableDropdown<VerticalVariable>.paginated(
-                requestItemCount: 10,
-                hintText: Text(
-                  cubit.canLoadData
-                      ? 'Select a vertical variable (optional)'
-                      : 'Enter domain first (4 digits)',
+                  ),
+                  child: child,
                 ),
-                isEnabled: cubit.canLoadData,
-                paginatedRequest: (page, searchKey) async {
-                  if (!cubit.canLoadData) {
-                    return [];
-                  }
-                  final verticalVariables = await cubit.fetchVerticalVariables(
-                    page: page,
-                    searchText: searchKey,
-                  );
-                  return verticalVariables
-                      .map(
-                        (verticalVariable) =>
-                            SearchableDropdownMenuItem<VerticalVariable>(
-                              value: verticalVariable,
-                              label: verticalVariable.title,
-                              child: ListTile(
-                                contentPadding: EdgeInsets.zero,
-                                title: Text(
-                                  verticalVariable.title,
-                                  style: Theme.of(context).textTheme.bodyMedium,
-                                ),
-                                subtitle: Text(
-                                  verticalVariable.groupName ?? '',
-                                  style: Theme.of(
-                                    context,
-                                  ).textTheme.bodySmall?.copyWith(
-                                    color:
-                                        Theme.of(
-                                          context,
-                                        ).colorScheme.onSurfaceVariant,
-                                  ),
-                                ),
-                              ),
-                            ),
-                      )
-                      .toList();
-                },
-                onChanged: (verticalVariable) {
-                  cubit.setVerticalGroup(verticalVariable?.id);
-                },
-                backgroundDecoration:
-                    (child) => Card(
-                      margin: EdgeInsets.zero,
-                      elevation: 0,
-                      shape: RoundedRectangleBorder(
-                        borderRadius: BorderRadius.circular(8),
-                        side: BorderSide(
-                          color: Theme.of(context).colorScheme.outline,
-                        ),
-                      ),
-                      child: child,
-                    ),
-              ),
-            ],
           ),
-        ],
-      ),
+        ),
+      ],
     );
   }
 }

--- a/app/example/lib/features/domains/presentation/widgets/domains_parameters_panel.dart
+++ b/app/example/lib/features/domains/presentation/widgets/domains_parameters_panel.dart
@@ -6,6 +6,7 @@ import 'package:stadata_example/core/constants/app_sizes.dart';
 import 'package:stadata_example/core/generated/strings.g.dart';
 import 'package:stadata_example/features/domains/presentation/cubit/domains_cubit.dart';
 import 'package:stadata_example/shared/cubit/base_cubit.dart';
+import 'package:stadata_example/shared/widgets/parameters_panel.dart';
 import 'package:stadata_flutter_sdk/stadata_flutter_sdk.dart';
 
 /// A reusable parameters panel widget for domains configuration
@@ -25,127 +26,70 @@ class DomainsParametersPanel extends StatelessWidget {
       builder: (context, state) {
         final cubit = context.read<DomainsCubit>();
 
-        return Container(
-          width: double.infinity,
-          padding: const EdgeInsets.all(AppSizes.spaceMd),
-          decoration: BoxDecoration(
-            color: Colors.white,
-            borderRadius: BorderRadius.circular(8),
-            border: Border.all(
-              color: Theme.of(
-                context,
-              ).colorScheme.outline.withValues(alpha: 0.3),
-            ),
-          ),
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              // Header
-              Row(
-                children: [
-                  Icon(
-                    Icons.settings,
-                    size: 16,
-                    color: Theme.of(context).colorScheme.primary,
+        return ParametersPanel(
+          title: t.domains.parameters.title,
+          children: [
+            // Domain Type Selector
+            ParameterField(
+              label: t.domains.parameters.domainType,
+              child: DropdownButtonFormField<DomainType>(
+                initialValue: cubit.currentType,
+                decoration: const InputDecoration(
+                  border: OutlineInputBorder(),
+                  isDense: true,
+                  contentPadding: EdgeInsets.symmetric(
+                    horizontal: AppSizes.spaceSm,
+                    vertical: AppSizes.spaceSm,
                   ),
-                  const Gap(AppSizes.spaceXs),
-                  Text(
-                    t.domains.parameters.title,
-                    style: Theme.of(context).textTheme.titleSmall?.copyWith(
-                      fontWeight: FontWeight.w600,
-                    ),
-                  ),
-                ],
-              ),
-              const Gap(AppSizes.spaceMd),
-
-              // Domain Type Selector
-              Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  Text(
-                    t.domains.parameters.domainType,
-                    style: Theme.of(context).textTheme.labelMedium?.copyWith(
-                      fontWeight: FontWeight.w500,
-                    ),
-                  ),
-                  const Gap(AppSizes.spaceXs),
-                  DropdownButtonFormField<DomainType>(
-                    initialValue: cubit.currentType,
-                    decoration: const InputDecoration(
-                      border: OutlineInputBorder(),
-                      isDense: true,
-                      contentPadding: EdgeInsets.symmetric(
-                        horizontal: AppSizes.spaceSm,
-                        vertical: AppSizes.spaceSm,
-                      ),
-                    ),
-                    items:
-                        DomainType.values.map((type) {
-                          return DropdownMenuItem(
-                            value: type,
-                            child: Text(_getTypeDisplayName(context, type)),
-                          );
-                        }).toList(),
-                    onChanged: (type) {
-                      if (type != null) {
-                        context.read<DomainsCubit>().changeType(type);
-                      }
-                    },
-                  ),
-                ],
-              ),
-
-              const Gap(AppSizes.spaceMd),
-
-              // Province Code Input (conditional)
-              if (cubit.requiresProvinceCode) ...[
-                Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    Text(
-                      '${t.domains.parameters.provinceCode} *',
-                      style: Theme.of(context).textTheme.labelMedium?.copyWith(
-                        fontWeight: FontWeight.w500,
-                      ),
-                    ),
-                    const Gap(AppSizes.spaceXs),
-                    TextFormField(
-                      controller: provinceCodeController,
-                      decoration: InputDecoration(
-                        border: const OutlineInputBorder(),
-                        hintText: t.domains.parameters.provinceCodeHint,
-                        isDense: true,
-                        contentPadding: const EdgeInsets.symmetric(
-                          horizontal: AppSizes.spaceSm,
-                          vertical: AppSizes.spaceSm,
-                        ),
-                      ),
-                      keyboardType: TextInputType.number,
-                      inputFormatters: [FilteringTextInputFormatter.digitsOnly],
-                      maxLength: 4,
-                      onChanged: (value) {
-                        context.read<DomainsCubit>().setProvinceCode(
-                          value.isEmpty ? null : value,
-                        );
-                      },
-                    ),
-                  ],
                 ),
-                const Gap(AppSizes.spaceMd),
-              ],
-
-              // Language Selector
-              Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  Text(
-                    t.domains.parameters.language,
-                    style: Theme.of(context).textTheme.labelMedium?.copyWith(
-                      fontWeight: FontWeight.w500,
+                items:
+                    DomainType.values.map((type) {
+                      return DropdownMenuItem(
+                        value: type,
+                        child: Text(_getTypeDisplayName(context, type)),
+                      );
+                    }).toList(),
+                onChanged: (type) {
+                  if (type != null) {
+                    context.read<DomainsCubit>().changeType(type);
+                  }
+                },
+              ),
+            ),
+            const Gap(AppSizes.spaceMd),
+            // Province Code Input (conditional)
+            if (cubit.requiresProvinceCode) ...[
+              ParameterField(
+                label: '${t.domains.parameters.provinceCode} *',
+                child: TextFormField(
+                  controller: provinceCodeController,
+                  decoration: InputDecoration(
+                    border: const OutlineInputBorder(),
+                    hintText: t.domains.parameters.provinceCodeHint,
+                    isDense: true,
+                    contentPadding: const EdgeInsets.symmetric(
+                      horizontal: AppSizes.spaceSm,
+                      vertical: AppSizes.spaceSm,
                     ),
                   ),
-                  const Gap(AppSizes.spaceXs),
+                  keyboardType: TextInputType.number,
+                  inputFormatters: [FilteringTextInputFormatter.digitsOnly],
+                  maxLength: 4,
+                  onChanged: (value) {
+                    context.read<DomainsCubit>().setProvinceCode(
+                      value.isEmpty ? null : value,
+                    );
+                  },
+                ),
+              ),
+              const Gap(AppSizes.spaceMd),
+            ],
+            // Language Selector
+            ParameterField(
+              label: t.domains.parameters.language,
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
                   DropdownButtonFormField<DataLanguage>(
                     initialValue: cubit.currentLanguage,
                     decoration: const InputDecoration(
@@ -190,8 +134,8 @@ class DomainsParametersPanel extends StatelessWidget {
                   ),
                 ],
               ),
-            ],
-          ),
+            ),
+          ],
         );
       },
     );

--- a/app/example/lib/features/glossary/presentation/widgets/glossary_parameters_panel.dart
+++ b/app/example/lib/features/glossary/presentation/widgets/glossary_parameters_panel.dart
@@ -5,6 +5,7 @@ import 'package:stadata_example/core/constants/app_sizes.dart';
 import 'package:stadata_example/core/generated/strings.g.dart';
 import 'package:stadata_example/features/glossary/presentation/cubit/glossary_cubit.dart';
 import 'package:stadata_example/shared/cubit/base_cubit.dart';
+import 'package:stadata_example/shared/widgets/parameters_panel.dart';
 import 'package:stadata_flutter_sdk/stadata_flutter_sdk.dart';
 
 class GlossaryParametersPanel extends StatelessWidget {
@@ -27,195 +28,132 @@ class GlossaryParametersPanel extends StatelessWidget {
       builder: (context, state) {
         final cubit = context.read<GlossaryCubit>();
 
-        return Container(
-          width: double.infinity,
-          padding: const EdgeInsets.all(AppSizes.spaceMd),
-          decoration: BoxDecoration(
-            color: Colors.white,
-            borderRadius: BorderRadius.circular(8),
-            border: Border.all(
-              color: Theme.of(
-                context,
-              ).colorScheme.outline.withValues(alpha: 0.3),
+        return ParametersPanel(
+          title: t.glossary.parameters.title,
+          children: [
+            // Domain Input
+            ParameterField(
+              label: '${t.glossary.parameters.domain} *',
+              child: TextFormField(
+                controller: domainController,
+                decoration: InputDecoration(
+                  border: const OutlineInputBorder(),
+                  hintText: t.glossary.parameters.domainHint,
+                  isDense: true,
+                  contentPadding: const EdgeInsets.symmetric(
+                    horizontal: AppSizes.spaceSm,
+                    vertical: AppSizes.spaceSm,
+                  ),
+                ),
+                keyboardType: TextInputType.number,
+                onChanged: cubit.changeDomain,
+              ),
             ),
-          ),
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              Row(
-                children: [
-                  Icon(
-                    Icons.settings,
-                    size: 16,
-                    color: Theme.of(context).colorScheme.primary,
+            const Gap(AppSizes.spaceMd),
+            // Keyword Input
+            ParameterField(
+              label: t.glossary.parameters.keyword,
+              child: TextFormField(
+                controller: keywordController,
+                decoration: InputDecoration(
+                  border: const OutlineInputBorder(),
+                  hintText: t.glossary.parameters.keywordHint,
+                  isDense: true,
+                  contentPadding: const EdgeInsets.symmetric(
+                    horizontal: AppSizes.spaceSm,
+                    vertical: AppSizes.spaceSm,
                   ),
-                  const Gap(AppSizes.spaceXs),
-                  Text(
-                    t.glossary.parameters.title,
-                    style: Theme.of(context).textTheme.titleSmall?.copyWith(
-                      fontWeight: FontWeight.w600,
-                    ),
+                ),
+                onChanged: cubit.setKeyword,
+              ),
+            ),
+            const Gap(AppSizes.spaceMd),
+            // Prefix Dropdown
+            ParameterField(
+              label: t.glossary.parameters.prefix,
+              child: DropdownButtonFormField<String>(
+                initialValue: cubit.prefix,
+                decoration: const InputDecoration(
+                  border: OutlineInputBorder(),
+                  isDense: true,
+                  contentPadding: EdgeInsets.symmetric(
+                    horizontal: AppSizes.spaceSm,
+                    vertical: AppSizes.spaceSm,
                   ),
+                ),
+                hint: Text(t.glossary.parameters.prefixHint),
+                menuMaxHeight: 300,
+                isExpanded: true,
+                items: [
+                  ...List.generate(26, (i) {
+                    final letter = String.fromCharCode(65 + i);
+                    return DropdownMenuItem<String>(
+                      value: letter,
+                      child: Text(letter),
+                    );
+                  }),
                 ],
+                onChanged: cubit.setPrefix,
               ),
-              const Gap(AppSizes.spaceMd),
-
-              // Domain Input
-              _ParameterField(
-                label: '${t.glossary.parameters.domain} *',
-                child: TextFormField(
-                  controller: domainController,
-                  decoration: InputDecoration(
-                    border: const OutlineInputBorder(),
-                    hintText: t.glossary.parameters.domainHint,
-                    isDense: true,
-                    contentPadding: const EdgeInsets.symmetric(
-                      horizontal: AppSizes.spaceSm,
-                      vertical: AppSizes.spaceSm,
-                    ),
+            ),
+            const Gap(AppSizes.spaceMd),
+            // Page Input
+            ParameterField(
+              label: t.glossary.parameters.page,
+              child: TextFormField(
+                controller: pageController,
+                decoration: const InputDecoration(
+                  border: OutlineInputBorder(),
+                  hintText: 'Enter page number',
+                  isDense: true,
+                  contentPadding: EdgeInsets.symmetric(
+                    horizontal: AppSizes.spaceSm,
+                    vertical: AppSizes.spaceSm,
                   ),
-                  keyboardType: TextInputType.number,
-                  onChanged: cubit.changeDomain,
                 ),
+                keyboardType: TextInputType.number,
+                textAlign: TextAlign.center,
+                onChanged: (value) {
+                  final p = int.tryParse(value);
+                  if (p != null && p > 0) {
+                    cubit.page = p;
+                  }
+                },
               ),
-
-              const Gap(AppSizes.spaceMd),
-
-              // Keyword Input
-              _ParameterField(
-                label: t.glossary.parameters.keyword,
-                child: TextFormField(
-                  controller: keywordController,
-                  decoration: InputDecoration(
-                    border: const OutlineInputBorder(),
-                    hintText: t.glossary.parameters.keywordHint,
-                    isDense: true,
-                    contentPadding: const EdgeInsets.symmetric(
-                      horizontal: AppSizes.spaceSm,
-                      vertical: AppSizes.spaceSm,
-                    ),
+            ),
+            const Gap(AppSizes.spaceMd),
+            // Language Selector
+            ParameterField(
+              label: t.glossary.parameters.language,
+              child: DropdownButtonFormField<DataLanguage>(
+                initialValue: cubit.currentLanguage,
+                decoration: const InputDecoration(
+                  border: OutlineInputBorder(),
+                  isDense: true,
+                  contentPadding: EdgeInsets.symmetric(
+                    horizontal: AppSizes.spaceSm,
+                    vertical: AppSizes.spaceSm,
                   ),
-                  onChanged: cubit.setKeyword,
                 ),
-              ),
-
-              const Gap(AppSizes.spaceMd),
-
-              // Prefix Dropdown
-              _ParameterField(
-                label: t.glossary.parameters.prefix,
-                child: DropdownButtonFormField<String>(
-                  initialValue: cubit.prefix,
-                  decoration: const InputDecoration(
-                    border: OutlineInputBorder(),
-                    isDense: true,
-                    contentPadding: EdgeInsets.symmetric(
-                      horizontal: AppSizes.spaceSm,
-                      vertical: AppSizes.spaceSm,
-                    ),
-                  ),
-                  hint: Text(t.glossary.parameters.prefixHint),
-                  menuMaxHeight: 300,
-                  isExpanded: true,
-                  items: [
-                    ...List.generate(26, (i) {
-                      final letter = String.fromCharCode(65 + i);
-                      return DropdownMenuItem<String>(
-                        value: letter,
-                        child: Text(letter),
+                items:
+                    DataLanguage.values.map((language) {
+                      return DropdownMenuItem<DataLanguage>(
+                        value: language,
+                        child: Text(
+                          language == DataLanguage.id
+                              ? 'Indonesian'
+                              : 'English',
+                        ),
                       );
-                    }),
-                  ],
-                  onChanged: cubit.setPrefix,
-                ),
+                    }).toList(),
+                onChanged: (value) {
+                  if (value != null) cubit.changeLanguage(value);
+                },
               ),
-
-              const Gap(AppSizes.spaceMd),
-
-              // Page Input
-              _ParameterField(
-                label: t.glossary.parameters.page,
-                child: TextFormField(
-                  controller: pageController,
-                  decoration: const InputDecoration(
-                    border: OutlineInputBorder(),
-                    hintText: 'Enter page number',
-                    isDense: true,
-                    contentPadding: EdgeInsets.symmetric(
-                      horizontal: AppSizes.spaceSm,
-                      vertical: AppSizes.spaceSm,
-                    ),
-                  ),
-                  keyboardType: TextInputType.number,
-                  textAlign: TextAlign.center,
-                  onChanged: (value) {
-                    final p = int.tryParse(value);
-                    if (p != null && p > 0) {
-                      cubit.page = p;
-                    }
-                  },
-                ),
-              ),
-
-              const Gap(AppSizes.spaceMd),
-
-              // Language Selector
-              _ParameterField(
-                label: t.glossary.parameters.language,
-                child: DropdownButtonFormField<DataLanguage>(
-                  initialValue: cubit.currentLanguage,
-                  decoration: const InputDecoration(
-                    border: OutlineInputBorder(),
-                    isDense: true,
-                    contentPadding: EdgeInsets.symmetric(
-                      horizontal: AppSizes.spaceSm,
-                      vertical: AppSizes.spaceSm,
-                    ),
-                  ),
-                  items:
-                      DataLanguage.values.map((language) {
-                        return DropdownMenuItem<DataLanguage>(
-                          value: language,
-                          child: Text(
-                            language == DataLanguage.id
-                                ? 'Indonesian'
-                                : 'English',
-                          ),
-                        );
-                      }).toList(),
-                  onChanged: (value) {
-                    if (value != null) cubit.changeLanguage(value);
-                  },
-                ),
-              ),
-            ],
-          ),
+            ),
+          ],
         );
       },
-    );
-  }
-}
-
-class _ParameterField extends StatelessWidget {
-  const _ParameterField({required this.label, required this.child});
-
-  final String label;
-  final Widget child;
-
-  @override
-  Widget build(BuildContext context) {
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        Text(
-          label,
-          style: Theme.of(context).textTheme.labelMedium?.copyWith(
-            fontWeight: FontWeight.w500,
-          ),
-        ),
-        const Gap(AppSizes.spaceXs),
-        child,
-      ],
     );
   }
 }

--- a/app/example/lib/features/infographics/presentation/widgets/infographics_parameters_panel.dart
+++ b/app/example/lib/features/infographics/presentation/widgets/infographics_parameters_panel.dart
@@ -5,6 +5,7 @@ import 'package:stadata_example/core/constants/app_sizes.dart';
 import 'package:stadata_example/core/generated/strings.g.dart';
 import 'package:stadata_example/features/infographics/presentation/cubit/infographics_cubit.dart';
 import 'package:stadata_example/shared/cubit/base_cubit.dart';
+import 'package:stadata_example/shared/widgets/parameters_panel.dart';
 import 'package:stadata_flutter_sdk/stadata_flutter_sdk.dart';
 
 /// A reusable parameters panel widget for infographics configuration
@@ -28,51 +29,15 @@ class InfographicsParametersPanel extends StatelessWidget {
       builder: (context, state) {
         final cubit = context.read<InfographicsCubit>();
 
-        return Container(
-          width: double.infinity,
-          padding: const EdgeInsets.all(AppSizes.spaceMd),
-          decoration: BoxDecoration(
-            color: Colors.white,
-            borderRadius: BorderRadius.circular(8),
-            border: Border.all(
-              color: Theme.of(
-                context,
-              ).colorScheme.outline.withValues(alpha: 0.3),
-            ),
-          ),
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              // Header
-              Row(
-                children: [
-                  Icon(
-                    Icons.settings,
-                    size: 16,
-                    color: Theme.of(context).colorScheme.primary,
-                  ),
-                  const Gap(AppSizes.spaceXs),
-                  Text(
-                    t.infographics.parameters.title,
-                    style: Theme.of(context).textTheme.titleSmall?.copyWith(
-                      fontWeight: FontWeight.w600,
-                    ),
-                  ),
-                ],
-              ),
-              const Gap(AppSizes.spaceMd),
-
-              // Domain Input
-              Column(
+        return ParametersPanel(
+          title: t.infographics.parameters.title,
+          children: [
+            // Domain Input
+            ParameterField(
+              label: '${t.infographics.parameters.domain} *',
+              child: Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
-                  Text(
-                    '${t.infographics.parameters.domain} *',
-                    style: Theme.of(context).textTheme.labelMedium?.copyWith(
-                      fontWeight: FontWeight.w500,
-                    ),
-                  ),
-                  const Gap(AppSizes.spaceXs),
                   TextFormField(
                     controller: domainController,
                     decoration: InputDecoration(
@@ -98,20 +63,14 @@ class InfographicsParametersPanel extends StatelessWidget {
                   ),
                 ],
               ),
-
-              const Gap(AppSizes.spaceMd),
-
-              // Keyword Input (optional)
-              Column(
+            ),
+            const Gap(AppSizes.spaceMd),
+            // Keyword Input (optional)
+            ParameterField(
+              label: t.infographics.parameters.keyword,
+              child: Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
-                  Text(
-                    t.infographics.parameters.keyword,
-                    style: Theme.of(context).textTheme.labelMedium?.copyWith(
-                      fontWeight: FontWeight.w500,
-                    ),
-                  ),
-                  const Gap(AppSizes.spaceXs),
                   TextFormField(
                     controller: keywordController,
                     decoration: InputDecoration(
@@ -136,20 +95,14 @@ class InfographicsParametersPanel extends StatelessWidget {
                   ),
                 ],
               ),
-
-              const Gap(AppSizes.spaceMd),
-
-              // Language Selector
-              Column(
+            ),
+            const Gap(AppSizes.spaceMd),
+            // Language Selector
+            ParameterField(
+              label: t.infographics.parameters.language,
+              child: Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
-                  Text(
-                    t.infographics.parameters.language,
-                    style: Theme.of(context).textTheme.labelMedium?.copyWith(
-                      fontWeight: FontWeight.w500,
-                    ),
-                  ),
-                  const Gap(AppSizes.spaceXs),
                   DropdownButtonFormField<DataLanguage>(
                     initialValue: cubit.currentLanguage,
                     decoration: const InputDecoration(
@@ -186,8 +139,8 @@ class InfographicsParametersPanel extends StatelessWidget {
                   ),
                 ],
               ),
-            ],
-          ),
+            ),
+          ],
         );
       },
     );

--- a/app/example/lib/features/news/presentation/widgets/news_parameters_panel.dart
+++ b/app/example/lib/features/news/presentation/widgets/news_parameters_panel.dart
@@ -5,6 +5,7 @@ import 'package:stadata_example/core/constants/app_sizes.dart';
 import 'package:stadata_example/core/generated/strings.g.dart';
 import 'package:stadata_example/features/news/presentation/cubit/news_cubit.dart';
 import 'package:stadata_example/shared/cubit/base_cubit.dart';
+import 'package:stadata_example/shared/widgets/parameters_panel.dart';
 import 'package:stadata_example/shared/widgets/searchable_dropdown.dart';
 import 'package:stadata_flutter_sdk/stadata_flutter_sdk.dart';
 
@@ -29,51 +30,15 @@ class NewsParametersPanel extends StatelessWidget {
       builder: (context, state) {
         final cubit = context.read<NewsCubit>();
 
-        return Container(
-          width: double.infinity,
-          padding: const EdgeInsets.all(AppSizes.spaceMd),
-          decoration: BoxDecoration(
-            color: Colors.white,
-            borderRadius: BorderRadius.circular(8),
-            border: Border.all(
-              color: Theme.of(
-                context,
-              ).colorScheme.outline.withValues(alpha: 0.3),
-            ),
-          ),
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              // Header
-              Row(
-                children: [
-                  Icon(
-                    Icons.settings,
-                    size: 16,
-                    color: Theme.of(context).colorScheme.primary,
-                  ),
-                  const Gap(AppSizes.spaceXs),
-                  Text(
-                    t.news.parameters.title,
-                    style: Theme.of(context).textTheme.titleSmall?.copyWith(
-                      fontWeight: FontWeight.w600,
-                    ),
-                  ),
-                ],
-              ),
-              const Gap(AppSizes.spaceMd),
-
-              // Domain Input
-              Column(
+        return ParametersPanel(
+          title: t.news.parameters.title,
+          children: [
+            // Domain Input
+            ParameterField(
+              label: '${t.news.parameters.domain} *',
+              child: Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
-                  Text(
-                    '${t.news.parameters.domain} *',
-                    style: Theme.of(context).textTheme.labelMedium?.copyWith(
-                      fontWeight: FontWeight.w500,
-                    ),
-                  ),
-                  const Gap(AppSizes.spaceXs),
                   TextFormField(
                     controller: domainController,
                     decoration: InputDecoration(
@@ -99,20 +64,14 @@ class NewsParametersPanel extends StatelessWidget {
                   ),
                 ],
               ),
-
-              const Gap(AppSizes.spaceMd),
-
-              // Keyword Input (optional)
-              Column(
+            ),
+            const Gap(AppSizes.spaceMd),
+            // Keyword Input (optional)
+            ParameterField(
+              label: t.news.parameters.keyword,
+              child: Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
-                  Text(
-                    t.news.parameters.keyword,
-                    style: Theme.of(context).textTheme.labelMedium?.copyWith(
-                      fontWeight: FontWeight.w500,
-                    ),
-                  ),
-                  const Gap(AppSizes.spaceXs),
                   TextFormField(
                     controller: keywordController,
                     decoration: InputDecoration(
@@ -137,20 +96,14 @@ class NewsParametersPanel extends StatelessWidget {
                   ),
                 ],
               ),
-
-              const Gap(AppSizes.spaceMd),
-
-              // News Category Dropdown (optional)
-              Column(
+            ),
+            const Gap(AppSizes.spaceMd),
+            // News Category Dropdown (optional)
+            ParameterField(
+              label: t.news.parameters.category,
+              child: Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
-                  Text(
-                    t.news.parameters.category,
-                    style: Theme.of(context).textTheme.labelMedium?.copyWith(
-                      fontWeight: FontWeight.w500,
-                    ),
-                  ),
-                  const Gap(AppSizes.spaceXs),
                   SearchableDropdown<NewsCategory>(
                     items: cubit.newsCategories,
                     value: cubit.newsCategories
@@ -181,111 +134,87 @@ class NewsParametersPanel extends StatelessWidget {
                   ),
                 ],
               ),
-
-              const Gap(AppSizes.spaceMd),
-
-              // Date Filters Row
-              Row(
-                children: [
-                  // Month Selector
-                  Expanded(
-                    child: Column(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: [
-                        Text(
-                          t.news.parameters.month,
-                          style: Theme.of(context).textTheme.labelMedium
-                              ?.copyWith(fontWeight: FontWeight.w500),
+            ),
+            const Gap(AppSizes.spaceMd),
+            // Date Filters Row
+            Row(
+              children: [
+                // Month Selector
+                Expanded(
+                  child: ParameterField(
+                    label: t.news.parameters.month,
+                    child: DropdownButtonFormField<int>(
+                      initialValue: cubit.month,
+                      decoration: const InputDecoration(
+                        border: OutlineInputBorder(),
+                        isDense: true,
+                        contentPadding: EdgeInsets.symmetric(
+                          horizontal: AppSizes.spaceSm,
+                          vertical: AppSizes.spaceSm,
                         ),
-                        const Gap(AppSizes.spaceXs),
-                        DropdownButtonFormField<int>(
-                          initialValue: cubit.month,
-                          decoration: const InputDecoration(
-                            border: OutlineInputBorder(),
-                            isDense: true,
-                            contentPadding: EdgeInsets.symmetric(
-                              horizontal: AppSizes.spaceSm,
-                              vertical: AppSizes.spaceSm,
-                            ),
+                      ),
+                      hint: Text(t.news.parameters.monthHint),
+                      menuMaxHeight: 300,
+                      isExpanded: true,
+                      items: List.generate(12, (index) {
+                        final month = index + 1;
+                        return DropdownMenuItem(
+                          value: month,
+                          child: Text(
+                            month.toString().padLeft(2, '0'),
+                            overflow: TextOverflow.ellipsis,
                           ),
-                          hint: Text(t.news.parameters.monthHint),
-                          menuMaxHeight: 300,
-                          isExpanded: true,
-                          items: List.generate(12, (index) {
-                            final month = index + 1;
-                            return DropdownMenuItem(
-                              value: month,
-                              child: Text(
-                                month.toString().padLeft(2, '0'),
-                                overflow: TextOverflow.ellipsis,
-                              ),
-                            );
-                          }),
-                          onChanged: (month) {
-                            context.read<NewsCubit>().setMonth(month);
-                          },
-                        ),
-                      ],
+                        );
+                      }),
+                      onChanged: (month) {
+                        context.read<NewsCubit>().setMonth(month);
+                      },
                     ),
                   ),
-                  const Gap(AppSizes.spaceMd),
-                  // Year Selector
-                  Expanded(
-                    child: Column(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: [
-                        Text(
-                          t.news.parameters.year,
-                          style: Theme.of(context).textTheme.labelMedium
-                              ?.copyWith(fontWeight: FontWeight.w500),
+                ),
+                const Gap(AppSizes.spaceMd),
+                // Year Selector
+                Expanded(
+                  child: ParameterField(
+                    label: t.news.parameters.year,
+                    child: DropdownButtonFormField<int>(
+                      initialValue: cubit.year,
+                      decoration: const InputDecoration(
+                        border: OutlineInputBorder(),
+                        isDense: true,
+                        contentPadding: EdgeInsets.symmetric(
+                          horizontal: AppSizes.spaceSm,
+                          vertical: AppSizes.spaceSm,
                         ),
-                        const Gap(AppSizes.spaceXs),
-                        DropdownButtonFormField<int>(
-                          initialValue: cubit.year,
-                          decoration: const InputDecoration(
-                            border: OutlineInputBorder(),
-                            isDense: true,
-                            contentPadding: EdgeInsets.symmetric(
-                              horizontal: AppSizes.spaceSm,
-                              vertical: AppSizes.spaceSm,
-                            ),
+                      ),
+                      hint: Text(t.news.parameters.yearHint),
+                      menuMaxHeight: 300,
+                      isExpanded: true,
+                      items: List.generate(10, (index) {
+                        final year = DateTime.now().year - index;
+                        return DropdownMenuItem(
+                          value: year,
+                          child: Text(
+                            year.toString(),
+                            overflow: TextOverflow.ellipsis,
                           ),
-                          hint: Text(t.news.parameters.yearHint),
-                          menuMaxHeight: 300,
-                          isExpanded: true,
-                          items: List.generate(10, (index) {
-                            final year = DateTime.now().year - index;
-                            return DropdownMenuItem(
-                              value: year,
-                              child: Text(
-                                year.toString(),
-                                overflow: TextOverflow.ellipsis,
-                              ),
-                            );
-                          }),
-                          onChanged: (year) {
-                            context.read<NewsCubit>().setYear(year);
-                          },
-                        ),
-                      ],
+                        );
+                      }),
+                      onChanged: (year) {
+                        context.read<NewsCubit>().setYear(year);
+                      },
                     ),
                   ),
-                ],
-              ),
-
-              const Gap(AppSizes.spaceMd),
-
-              // Page Input
-              Column(
+                ),
+              ],
+            ),
+            const Gap(AppSizes.spaceMd),
+            // Page Input
+            ParameterField(
+              label: t.news.parameters.page,
+              child: Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
-                  Text(
-                    t.news.parameters.page,
-                    style: Theme.of(context).textTheme.labelMedium?.copyWith(
-                      fontWeight: FontWeight.w500,
-                    ),
-                  ),
-                  const Gap(AppSizes.spaceXs),
                   TextFormField(
                     controller: pageController,
                     decoration: const InputDecoration(
@@ -315,20 +244,14 @@ class NewsParametersPanel extends StatelessWidget {
                   ),
                 ],
               ),
-
-              const Gap(AppSizes.spaceMd),
-
-              // Language Selector
-              Column(
+            ),
+            const Gap(AppSizes.spaceMd),
+            // Language Selector
+            ParameterField(
+              label: t.news.parameters.language,
+              child: Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
-                  Text(
-                    t.news.parameters.language,
-                    style: Theme.of(context).textTheme.labelMedium?.copyWith(
-                      fontWeight: FontWeight.w500,
-                    ),
-                  ),
-                  const Gap(AppSizes.spaceXs),
                   DropdownButtonFormField<DataLanguage>(
                     initialValue: cubit.currentLanguage,
                     decoration: const InputDecoration(
@@ -365,8 +288,8 @@ class NewsParametersPanel extends StatelessWidget {
                   ),
                 ],
               ),
-            ],
-          ),
+            ),
+          ],
         );
       },
     );

--- a/app/example/lib/features/news_categories/presentation/widgets/news_categories_parameters_panel.dart
+++ b/app/example/lib/features/news_categories/presentation/widgets/news_categories_parameters_panel.dart
@@ -5,6 +5,7 @@ import 'package:stadata_example/core/constants/app_sizes.dart';
 import 'package:stadata_example/core/generated/strings.g.dart';
 import 'package:stadata_example/features/news_categories/presentation/cubit/news_categories_cubit.dart';
 import 'package:stadata_example/shared/cubit/base_cubit.dart';
+import 'package:stadata_example/shared/widgets/parameters_panel.dart';
 import 'package:stadata_flutter_sdk/stadata_flutter_sdk.dart';
 
 class NewsCategoriesParametersPanel extends StatelessWidget {
@@ -23,51 +24,15 @@ class NewsCategoriesParametersPanel extends StatelessWidget {
       builder: (context, state) {
         final cubit = context.read<NewsCategoriesCubit>();
 
-        return Container(
-          width: double.infinity,
-          padding: const EdgeInsets.all(AppSizes.spaceMd),
-          decoration: BoxDecoration(
-            color: Colors.white,
-            borderRadius: BorderRadius.circular(8),
-            border: Border.all(
-              color: Theme.of(
-                context,
-              ).colorScheme.outline.withValues(alpha: 0.3),
-            ),
-          ),
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              // Header
-              Row(
-                children: [
-                  Icon(
-                    Icons.settings,
-                    size: 16,
-                    color: Theme.of(context).colorScheme.primary,
-                  ),
-                  const Gap(AppSizes.spaceXs),
-                  Text(
-                    t.newsCategories.parameters.title,
-                    style: Theme.of(context).textTheme.titleSmall?.copyWith(
-                      fontWeight: FontWeight.w600,
-                    ),
-                  ),
-                ],
-              ),
-              const Gap(AppSizes.spaceMd),
-
-              // Domain Input
-              Column(
+        return ParametersPanel(
+          title: t.newsCategories.parameters.title,
+          children: [
+            // Domain Input
+            ParameterField(
+              label: t.newsCategories.parameters.domain,
+              child: Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
-                  Text(
-                    t.newsCategories.parameters.domain,
-                    style: Theme.of(context).textTheme.labelMedium?.copyWith(
-                      fontWeight: FontWeight.w500,
-                    ),
-                  ),
-                  const Gap(AppSizes.spaceXs),
                   TextFormField(
                     controller: domainController,
                     decoration: InputDecoration(
@@ -90,20 +55,14 @@ class NewsCategoriesParametersPanel extends StatelessWidget {
                   ),
                 ],
               ),
-
-              const Gap(AppSizes.spaceMd),
-
-              // Language Selection
-              Column(
+            ),
+            const Gap(AppSizes.spaceMd),
+            // Language Selection
+            ParameterField(
+              label: t.newsCategories.parameters.language,
+              child: Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
-                  Text(
-                    t.newsCategories.parameters.language,
-                    style: Theme.of(context).textTheme.labelMedium?.copyWith(
-                      fontWeight: FontWeight.w500,
-                    ),
-                  ),
-                  const Gap(AppSizes.spaceXs),
                   DropdownButtonFormField<DataLanguage>(
                     initialValue: cubit.currentLanguage,
                     decoration: const InputDecoration(
@@ -143,8 +102,8 @@ class NewsCategoriesParametersPanel extends StatelessWidget {
                   ),
                 ],
               ),
-            ],
-          ),
+            ),
+          ],
         );
       },
     );

--- a/app/example/lib/features/periods/presentation/widgets/periods_parameters_panel.dart
+++ b/app/example/lib/features/periods/presentation/widgets/periods_parameters_panel.dart
@@ -6,6 +6,7 @@ import 'package:searchable_paginated_dropdown/searchable_paginated_dropdown.dart
 import 'package:stadata_example/core/constants/app_sizes.dart';
 import 'package:stadata_example/core/generated/strings.g.dart';
 import 'package:stadata_example/features/periods/presentation/cubit/periods_cubit.dart';
+import 'package:stadata_example/shared/widgets/parameters_panel.dart';
 import 'package:stadata_flutter_sdk/stadata_flutter_sdk.dart';
 
 class PeriodsParametersPanel extends StatefulWidget {
@@ -36,181 +37,127 @@ class _PeriodsParametersPanelState extends State<PeriodsParametersPanel> {
     final t = Translations.of(context);
     final cubit = context.read<PeriodsCubit>();
 
-    return Container(
-      width: double.infinity,
-      padding: const EdgeInsets.all(AppSizes.spaceMd),
-      decoration: BoxDecoration(
-        color: Colors.white,
-        borderRadius: BorderRadius.circular(8),
-        border: Border.all(
-          color: Theme.of(context).colorScheme.outline.withValues(alpha: 0.3),
+    return ParametersPanel(
+      icon: Icons.tune,
+      title: 'Parameters',
+      children: [
+        // Domain field
+        ParameterField(
+          label: 'Domain *',
+          child: TextFormField(
+            controller: _domainController,
+            decoration: const InputDecoration(
+              border: OutlineInputBorder(),
+              hintText: 'e.g., 7200 (4 digits)',
+              isDense: true,
+              contentPadding: EdgeInsets.symmetric(
+                horizontal: AppSizes.spaceSm,
+                vertical: AppSizes.spaceSm,
+              ),
+            ),
+            keyboardType: TextInputType.number,
+            inputFormatters: [FilteringTextInputFormatter.digitsOnly],
+            maxLength: 4,
+            onChanged: cubit.setDomain,
+          ),
         ),
-      ),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Row(
-            children: [
-              Icon(
-                Icons.tune,
-                size: 16,
-                color: Theme.of(context).colorScheme.primary,
+        const Gap(AppSizes.spaceMd),
+        // Language dropdown
+        ParameterField(
+          label: 'Language',
+          child: DropdownButtonFormField<DataLanguage>(
+            initialValue: cubit.currentLanguage,
+            decoration: const InputDecoration(
+              border: OutlineInputBorder(),
+              isDense: true,
+              contentPadding: EdgeInsets.symmetric(
+                horizontal: AppSizes.spaceSm,
+                vertical: AppSizes.spaceSm,
               ),
-              const Gap(AppSizes.spaceXs),
-              Text(
-                'Parameters',
-                style: Theme.of(
-                  context,
-                ).textTheme.titleSmall?.copyWith(fontWeight: FontWeight.w600),
-              ),
-            ],
-          ),
-          const Gap(AppSizes.spaceMd),
-          // Domain field
-          Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              Text(
-                'Domain *',
-                style: Theme.of(
-                  context,
-                ).textTheme.labelMedium?.copyWith(fontWeight: FontWeight.w500),
-              ),
-              const Gap(AppSizes.spaceXs),
-              TextFormField(
-                controller: _domainController,
-                decoration: const InputDecoration(
-                  border: OutlineInputBorder(),
-                  hintText: 'e.g., 7200 (4 digits)',
-                  isDense: true,
-                  contentPadding: EdgeInsets.symmetric(
-                    horizontal: AppSizes.spaceSm,
-                    vertical: AppSizes.spaceSm,
-                  ),
-                ),
-                keyboardType: TextInputType.number,
-                inputFormatters: [FilteringTextInputFormatter.digitsOnly],
-                maxLength: 4,
-                onChanged: cubit.setDomain,
-              ),
-            ],
-          ),
-          const Gap(AppSizes.spaceMd),
-          // Language dropdown
-          Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              Text(
-                'Language',
-                style: Theme.of(
-                  context,
-                ).textTheme.labelMedium?.copyWith(fontWeight: FontWeight.w500),
-              ),
-              const Gap(AppSizes.spaceXs),
-              DropdownButtonFormField<DataLanguage>(
-                initialValue: cubit.currentLanguage,
-                decoration: const InputDecoration(
-                  border: OutlineInputBorder(),
-                  isDense: true,
-                  contentPadding: EdgeInsets.symmetric(
-                    horizontal: AppSizes.spaceSm,
-                    vertical: AppSizes.spaceSm,
-                  ),
-                ),
-                items:
-                    DataLanguage.values.map((lang) {
-                      return DropdownMenuItem(
-                        value: lang,
-                        child: Text(
-                          lang == DataLanguage.id
-                              ? t.instructions.languageLabels.indonesian
-                              : t.instructions.languageLabels.english,
-                        ),
-                      );
-                    }).toList(),
-                onChanged: (value) {
-                  if (value != null) {
-                    cubit.changeLanguage(value);
-                  }
-                },
-              ),
-            ],
-          ),
-          const Gap(AppSizes.spaceMd),
-          // Variable dropdown (optional, paginated)
-          Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              Text(
-                'Variable ID (Optional)',
-                style: Theme.of(
-                  context,
-                ).textTheme.labelMedium?.copyWith(fontWeight: FontWeight.w500),
-              ),
-              const Gap(AppSizes.spaceXs),
-              SearchableDropdown<Variable>.paginated(
-                requestItemCount: 10,
-                hintText: Text(
-                  cubit.canLoadData
-                      ? 'Select a variable (optional)'
-                      : 'Enter domain first (4 digits)',
-                ),
-                isEnabled: cubit.canLoadData,
-                paginatedRequest: (page, searchKey) async {
-                  if (!cubit.canLoadData) {
-                    return [];
-                  }
-                  final variables = await cubit.fetchVariables(
-                    page: page,
-                    searchText: searchKey,
+            ),
+            items:
+                DataLanguage.values.map((lang) {
+                  return DropdownMenuItem(
+                    value: lang,
+                    child: Text(
+                      lang == DataLanguage.id
+                          ? t.instructions.languageLabels.indonesian
+                          : t.instructions.languageLabels.english,
+                    ),
                   );
-                  return variables
-                      .map(
-                        (variable) => SearchableDropdownMenuItem<Variable>(
-                          value: variable,
-                          label: variable.title,
-                          child: ListTile(
-                            contentPadding: EdgeInsets.zero,
-                            title: Text(
-                              variable.title,
-                              style: Theme.of(context).textTheme.bodyMedium,
-                            ),
-                            subtitle: Text(
-                              variable.subjectName,
-                              style: Theme.of(
-                                context,
-                              ).textTheme.bodySmall?.copyWith(
-                                color:
-                                    Theme.of(
-                                      context,
-                                    ).colorScheme.onSurfaceVariant,
-                              ),
-                            ),
+                }).toList(),
+            onChanged: (value) {
+              if (value != null) {
+                cubit.changeLanguage(value);
+              }
+            },
+          ),
+        ),
+        const Gap(AppSizes.spaceMd),
+        // Variable dropdown (optional, paginated)
+        ParameterField(
+          label: 'Variable ID (Optional)',
+          child: SearchableDropdown<Variable>.paginated(
+            requestItemCount: 10,
+            hintText: Text(
+              cubit.canLoadData
+                  ? 'Select a variable (optional)'
+                  : 'Enter domain first (4 digits)',
+            ),
+            isEnabled: cubit.canLoadData,
+            paginatedRequest: (page, searchKey) async {
+              if (!cubit.canLoadData) {
+                return [];
+              }
+              final variables = await cubit.fetchVariables(
+                page: page,
+                searchText: searchKey,
+              );
+              return variables
+                  .map(
+                    (variable) => SearchableDropdownMenuItem<Variable>(
+                      value: variable,
+                      label: variable.title,
+                      child: ListTile(
+                        contentPadding: EdgeInsets.zero,
+                        title: Text(
+                          variable.title,
+                          style: Theme.of(context).textTheme.bodyMedium,
+                        ),
+                        subtitle: Text(
+                          variable.subjectName,
+                          style: Theme.of(
+                            context,
+                          ).textTheme.bodySmall?.copyWith(
+                            color:
+                                Theme.of(
+                                  context,
+                                ).colorScheme.onSurfaceVariant,
                           ),
                         ),
-                      )
-                      .toList();
-                },
-                onChanged: (variable) {
-                  cubit.setVariableID(variable?.id);
-                },
-                backgroundDecoration:
-                    (child) => Card(
-                      margin: EdgeInsets.zero,
-                      elevation: 0,
-                      shape: RoundedRectangleBorder(
-                        borderRadius: BorderRadius.circular(8),
-                        side: BorderSide(
-                          color: Theme.of(context).colorScheme.outline,
-                        ),
                       ),
-                      child: child,
                     ),
-              ),
-            ],
+                  )
+                  .toList();
+            },
+            onChanged: (variable) {
+              cubit.setVariableID(variable?.id);
+            },
+            backgroundDecoration:
+                (child) => Card(
+                  margin: EdgeInsets.zero,
+                  elevation: 0,
+                  shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(8),
+                    side: BorderSide(
+                      color: Theme.of(context).colorScheme.outline,
+                    ),
+                  ),
+                  child: child,
+                ),
           ),
-        ],
-      ),
+        ),
+      ],
     );
   }
 }

--- a/app/example/lib/features/press_releases/presentation/widgets/press_releases_parameters_panel.dart
+++ b/app/example/lib/features/press_releases/presentation/widgets/press_releases_parameters_panel.dart
@@ -6,6 +6,7 @@ import 'package:stadata_example/core/constants/app_sizes.dart';
 import 'package:stadata_example/core/generated/strings.g.dart';
 import 'package:stadata_example/features/press_releases/presentation/cubit/press_releases_cubit.dart';
 import 'package:stadata_example/shared/cubit/base_cubit.dart';
+import 'package:stadata_example/shared/widgets/parameters_panel.dart';
 import 'package:stadata_flutter_sdk/stadata_flutter_sdk.dart';
 
 class PressReleasesParametersPanel extends StatelessWidget {
@@ -24,84 +25,38 @@ class PressReleasesParametersPanel extends StatelessWidget {
       builder: (context, state) {
         final cubit = context.read<PressReleasesCubit>();
 
-        return Container(
-          width: double.infinity,
-          padding: const EdgeInsets.all(AppSizes.spaceMd),
-          decoration: BoxDecoration(
-            color: Colors.white,
-            borderRadius: BorderRadius.circular(8),
-            border: Border.all(
-              color: Theme.of(
-                context,
-              ).colorScheme.outline.withValues(alpha: 0.3),
+        return ParametersPanel(
+          title: 'Parameters',
+          children: [
+            ParameterField(
+              label: 'Domain *',
+              child: TextFormField(
+                controller: domainController,
+                decoration: const InputDecoration(
+                  border: OutlineInputBorder(),
+                  hintText: 'e.g., 7200',
+                  isDense: true,
+                  contentPadding: EdgeInsets.symmetric(
+                    horizontal: AppSizes.spaceSm,
+                    vertical: AppSizes.spaceSm,
+                  ),
+                ),
+                keyboardType: TextInputType.number,
+                inputFormatters: [FilteringTextInputFormatter.digitsOnly],
+                maxLength: 4,
+                onChanged: (value) {
+                  context.read<PressReleasesCubit>().setDomain(
+                    value.isEmpty ? null : value,
+                  );
+                },
+              ),
             ),
-          ),
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              Row(
-                children: [
-                  Icon(
-                    Icons.settings,
-                    size: 16,
-                    color: Theme.of(context).colorScheme.primary,
-                  ),
-                  const Gap(AppSizes.spaceXs),
-                  Text(
-                    'Parameters',
-                    style: Theme.of(context).textTheme.titleSmall?.copyWith(
-                      fontWeight: FontWeight.w600,
-                    ),
-                  ),
-                ],
-              ),
-              const Gap(AppSizes.spaceMd),
-
-              Column(
+            const Gap(AppSizes.spaceMd),
+            ParameterField(
+              label: 'Language',
+              child: Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
-                  Text(
-                    'Domain *',
-                    style: Theme.of(context).textTheme.labelMedium?.copyWith(
-                      fontWeight: FontWeight.w500,
-                    ),
-                  ),
-                  const Gap(AppSizes.spaceXs),
-                  TextFormField(
-                    controller: domainController,
-                    decoration: const InputDecoration(
-                      border: OutlineInputBorder(),
-                      hintText: 'e.g., 7200',
-                      isDense: true,
-                      contentPadding: EdgeInsets.symmetric(
-                        horizontal: AppSizes.spaceSm,
-                        vertical: AppSizes.spaceSm,
-                      ),
-                    ),
-                    keyboardType: TextInputType.number,
-                    inputFormatters: [FilteringTextInputFormatter.digitsOnly],
-                    maxLength: 4,
-                    onChanged: (value) {
-                      context.read<PressReleasesCubit>().setDomain(
-                        value.isEmpty ? null : value,
-                      );
-                    },
-                  ),
-                ],
-              ),
-
-              const Gap(AppSizes.spaceMd),
-
-              Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  Text(
-                    'Language',
-                    style: Theme.of(context).textTheme.labelMedium?.copyWith(
-                      fontWeight: FontWeight.w500,
-                    ),
-                  ),
-                  const Gap(AppSizes.spaceXs),
                   DropdownButtonFormField<DataLanguage>(
                     initialValue: cubit.currentLanguage,
                     decoration: const InputDecoration(
@@ -148,129 +103,99 @@ class PressReleasesParametersPanel extends StatelessWidget {
                   ),
                 ],
               ),
-
-              const Gap(AppSizes.spaceMd),
-
-              Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  Text(
-                    'Keyword',
-                    style: Theme.of(context).textTheme.labelMedium?.copyWith(
-                      fontWeight: FontWeight.w500,
-                    ),
+            ),
+            const Gap(AppSizes.spaceMd),
+            ParameterField(
+              label: 'Keyword',
+              child: TextFormField(
+                controller: keywordController,
+                decoration: const InputDecoration(
+                  border: OutlineInputBorder(),
+                  hintText: 'Search by keyword',
+                  isDense: true,
+                  contentPadding: EdgeInsets.symmetric(
+                    horizontal: AppSizes.spaceSm,
+                    vertical: AppSizes.spaceSm,
                   ),
-                  const Gap(AppSizes.spaceXs),
-                  TextFormField(
-                    controller: keywordController,
-                    decoration: const InputDecoration(
-                      border: OutlineInputBorder(),
-                      hintText: 'Search by keyword',
-                      isDense: true,
-                      contentPadding: EdgeInsets.symmetric(
-                        horizontal: AppSizes.spaceSm,
-                        vertical: AppSizes.spaceSm,
+                ),
+                onChanged: (value) {
+                  context.read<PressReleasesCubit>().setKeyword(
+                    value.isEmpty ? null : value,
+                  );
+                },
+              ),
+            ),
+            const Gap(AppSizes.spaceMd),
+            Row(
+              children: [
+                Expanded(
+                  child: ParameterField(
+                    label: 'Month',
+                    child: DropdownButtonFormField<int>(
+                      initialValue: cubit.month,
+                      decoration: const InputDecoration(
+                        border: OutlineInputBorder(),
+                        isDense: true,
+                        contentPadding: EdgeInsets.symmetric(
+                          horizontal: AppSizes.spaceSm,
+                          vertical: AppSizes.spaceSm,
+                        ),
                       ),
-                    ),
-                    onChanged: (value) {
-                      context.read<PressReleasesCubit>().setKeyword(
-                        value.isEmpty ? null : value,
-                      );
-                    },
-                  ),
-                ],
-              ),
-
-              const Gap(AppSizes.spaceMd),
-
-              Row(
-                children: [
-                  Expanded(
-                    child: Column(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: [
-                        Text(
-                          'Month',
-                          style: Theme.of(context).textTheme.labelMedium
-                              ?.copyWith(fontWeight: FontWeight.w500),
-                        ),
-                        const Gap(AppSizes.spaceXs),
-                        DropdownButtonFormField<int>(
-                          initialValue: cubit.month,
-                          decoration: const InputDecoration(
-                            border: OutlineInputBorder(),
-                            isDense: true,
-                            contentPadding: EdgeInsets.symmetric(
-                              horizontal: AppSizes.spaceSm,
-                              vertical: AppSizes.spaceSm,
-                            ),
-                          ),
-                          hint: const Text('Select month'),
-                          items: List.generate(12, (index) {
-                            final month = index + 1;
-                            return DropdownMenuItem(
-                              value: month,
-                              child: Text(_getMonthName(context, month)),
-                            );
-                          }),
-                          onChanged: (value) {
-                            context.read<PressReleasesCubit>().setMonth(value);
-                          },
-                        ),
-                      ],
+                      hint: const Text('Select month'),
+                      items: List.generate(12, (index) {
+                        final month = index + 1;
+                        return DropdownMenuItem(
+                          value: month,
+                          child: Text(_getMonthName(context, month)),
+                        );
+                      }),
+                      onChanged: (value) {
+                        context.read<PressReleasesCubit>().setMonth(value);
+                      },
                     ),
                   ),
-                  const Gap(AppSizes.spaceSm),
-                  Expanded(
-                    child: Column(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: [
-                        Text(
-                          'Year',
-                          style: Theme.of(context).textTheme.labelMedium
-                              ?.copyWith(fontWeight: FontWeight.w500),
+                ),
+                const Gap(AppSizes.spaceSm),
+                Expanded(
+                  child: ParameterField(
+                    label: 'Year',
+                    child: DropdownButtonFormField<int>(
+                      initialValue: cubit.year,
+                      decoration: const InputDecoration(
+                        border: OutlineInputBorder(),
+                        isDense: true,
+                        contentPadding: EdgeInsets.symmetric(
+                          horizontal: AppSizes.spaceSm,
+                          vertical: AppSizes.spaceSm,
                         ),
-                        const Gap(AppSizes.spaceXs),
-                        DropdownButtonFormField<int>(
-                          initialValue: cubit.year,
-                          decoration: const InputDecoration(
-                            border: OutlineInputBorder(),
-                            isDense: true,
-                            contentPadding: EdgeInsets.symmetric(
-                              horizontal: AppSizes.spaceSm,
-                              vertical: AppSizes.spaceSm,
-                            ),
-                          ),
-                          hint: const Text('Select year'),
-                          items: _generateYearItems(),
-                          onChanged: (value) {
-                            context.read<PressReleasesCubit>().setYear(value);
-                          },
-                        ),
-                      ],
+                      ),
+                      hint: const Text('Select year'),
+                      items: _generateYearItems(),
+                      onChanged: (value) {
+                        context.read<PressReleasesCubit>().setYear(value);
+                      },
                     ),
-                  ),
-                ],
-              ),
-
-              if (cubit.keyword != null ||
-                  cubit.month != null ||
-                  cubit.year != null) ...[
-                const Gap(AppSizes.spaceMd),
-                SizedBox(
-                  width: double.infinity,
-                  child: OutlinedButton.icon(
-                    onPressed: () {
-                      keywordController.clear();
-                      context.read<PressReleasesCubit>().clearFilters();
-                    },
-                    icon: const Icon(Icons.clear, size: 16),
-                    label: const Text('Clear Filters'),
                   ),
                 ),
               ],
+            ),
+            if (cubit.keyword != null ||
+                cubit.month != null ||
+                cubit.year != null) ...[
+              const Gap(AppSizes.spaceMd),
+              SizedBox(
+                width: double.infinity,
+                child: OutlinedButton.icon(
+                  onPressed: () {
+                    keywordController.clear();
+                    context.read<PressReleasesCubit>().clearFilters();
+                  },
+                  icon: const Icon(Icons.clear, size: 16),
+                  label: const Text('Clear Filters'),
+                ),
+              ),
             ],
-          ),
+          ],
         );
       },
     );

--- a/app/example/lib/features/publications/presentation/widgets/publications_parameters_panel.dart
+++ b/app/example/lib/features/publications/presentation/widgets/publications_parameters_panel.dart
@@ -6,6 +6,7 @@ import 'package:stadata_example/core/constants/app_sizes.dart';
 import 'package:stadata_example/core/generated/strings.g.dart';
 import 'package:stadata_example/features/publications/presentation/cubit/publications_cubit.dart';
 import 'package:stadata_example/shared/cubit/base_cubit.dart';
+import 'package:stadata_example/shared/widgets/parameters_panel.dart';
 import 'package:stadata_flutter_sdk/stadata_flutter_sdk.dart';
 
 /// A reusable parameters panel widget for publications configuration
@@ -27,87 +28,40 @@ class PublicationsParametersPanel extends StatelessWidget {
       builder: (context, state) {
         final cubit = context.read<PublicationsCubit>();
 
-        return Container(
-          width: double.infinity,
-          padding: const EdgeInsets.all(AppSizes.spaceMd),
-          decoration: BoxDecoration(
-            color: Colors.white,
-            borderRadius: BorderRadius.circular(8),
-            border: Border.all(
-              color: Theme.of(
-                context,
-              ).colorScheme.outline.withValues(alpha: 0.3),
+        return ParametersPanel(
+          title: t.publications.parameters.title,
+          children: [
+            // Domain Input (required)
+            ParameterField(
+              label: '${t.publications.parameters.domain} *',
+              child: TextFormField(
+                controller: domainController,
+                decoration: InputDecoration(
+                  border: const OutlineInputBorder(),
+                  hintText: t.publications.parameters.domainHint,
+                  isDense: true,
+                  contentPadding: const EdgeInsets.symmetric(
+                    horizontal: AppSizes.spaceSm,
+                    vertical: AppSizes.spaceSm,
+                  ),
+                ),
+                keyboardType: TextInputType.number,
+                inputFormatters: [FilteringTextInputFormatter.digitsOnly],
+                maxLength: 4,
+                onChanged: (value) {
+                  context.read<PublicationsCubit>().setDomain(
+                    value.isEmpty ? null : value,
+                  );
+                },
+              ),
             ),
-          ),
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              // Header
-              Row(
-                children: [
-                  Icon(
-                    Icons.settings,
-                    size: 16,
-                    color: Theme.of(context).colorScheme.primary,
-                  ),
-                  const Gap(AppSizes.spaceXs),
-                  Text(
-                    t.publications.parameters.title,
-                    style: Theme.of(context).textTheme.titleSmall?.copyWith(
-                      fontWeight: FontWeight.w600,
-                    ),
-                  ),
-                ],
-              ),
-              const Gap(AppSizes.spaceMd),
-
-              // Domain Input (required)
-              Column(
+            const Gap(AppSizes.spaceMd),
+            // Language Selector
+            ParameterField(
+              label: t.publications.parameters.language,
+              child: Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
-                  Text(
-                    '${t.publications.parameters.domain} *',
-                    style: Theme.of(context).textTheme.labelMedium?.copyWith(
-                      fontWeight: FontWeight.w500,
-                    ),
-                  ),
-                  const Gap(AppSizes.spaceXs),
-                  TextFormField(
-                    controller: domainController,
-                    decoration: InputDecoration(
-                      border: const OutlineInputBorder(),
-                      hintText: t.publications.parameters.domainHint,
-                      isDense: true,
-                      contentPadding: const EdgeInsets.symmetric(
-                        horizontal: AppSizes.spaceSm,
-                        vertical: AppSizes.spaceSm,
-                      ),
-                    ),
-                    keyboardType: TextInputType.number,
-                    inputFormatters: [FilteringTextInputFormatter.digitsOnly],
-                    maxLength: 4,
-                    onChanged: (value) {
-                      context.read<PublicationsCubit>().setDomain(
-                        value.isEmpty ? null : value,
-                      );
-                    },
-                  ),
-                ],
-              ),
-
-              const Gap(AppSizes.spaceMd),
-
-              // Language Selector
-              Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  Text(
-                    t.publications.parameters.language,
-                    style: Theme.of(context).textTheme.labelMedium?.copyWith(
-                      fontWeight: FontWeight.w500,
-                    ),
-                  ),
-                  const Gap(AppSizes.spaceXs),
                   DropdownButtonFormField<DataLanguage>(
                     initialValue: cubit.currentLanguage,
                     decoration: const InputDecoration(
@@ -152,134 +106,104 @@ class PublicationsParametersPanel extends StatelessWidget {
                   ),
                 ],
               ),
-
-              const Gap(AppSizes.spaceMd),
-
-              // Keyword Input (optional)
-              Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  Text(
-                    t.publications.parameters.keyword,
-                    style: Theme.of(context).textTheme.labelMedium?.copyWith(
-                      fontWeight: FontWeight.w500,
-                    ),
+            ),
+            const Gap(AppSizes.spaceMd),
+            // Keyword Input (optional)
+            ParameterField(
+              label: t.publications.parameters.keyword,
+              child: TextFormField(
+                controller: keywordController,
+                decoration: InputDecoration(
+                  border: const OutlineInputBorder(),
+                  hintText: t.publications.parameters.keywordHint,
+                  isDense: true,
+                  contentPadding: const EdgeInsets.symmetric(
+                    horizontal: AppSizes.spaceSm,
+                    vertical: AppSizes.spaceSm,
                   ),
-                  const Gap(AppSizes.spaceXs),
-                  TextFormField(
-                    controller: keywordController,
-                    decoration: InputDecoration(
-                      border: const OutlineInputBorder(),
-                      hintText: t.publications.parameters.keywordHint,
-                      isDense: true,
-                      contentPadding: const EdgeInsets.symmetric(
-                        horizontal: AppSizes.spaceSm,
-                        vertical: AppSizes.spaceSm,
+                ),
+                onChanged: (value) {
+                  context.read<PublicationsCubit>().setKeyword(
+                    value.isEmpty ? null : value,
+                  );
+                },
+              ),
+            ),
+            const Gap(AppSizes.spaceMd),
+            // Month and Year filters
+            Row(
+              children: [
+                // Month selector
+                Expanded(
+                  child: ParameterField(
+                    label: t.publications.parameters.month,
+                    child: DropdownButtonFormField<int>(
+                      initialValue: cubit.month,
+                      decoration: const InputDecoration(
+                        border: OutlineInputBorder(),
+                        isDense: true,
+                        contentPadding: EdgeInsets.symmetric(
+                          horizontal: AppSizes.spaceSm,
+                          vertical: AppSizes.spaceSm,
+                        ),
                       ),
-                    ),
-                    onChanged: (value) {
-                      context.read<PublicationsCubit>().setKeyword(
-                        value.isEmpty ? null : value,
-                      );
-                    },
-                  ),
-                ],
-              ),
-
-              const Gap(AppSizes.spaceMd),
-
-              // Month and Year filters
-              Row(
-                children: [
-                  // Month selector
-                  Expanded(
-                    child: Column(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: [
-                        Text(
-                          t.publications.parameters.month,
-                          style: Theme.of(context).textTheme.labelMedium
-                              ?.copyWith(fontWeight: FontWeight.w500),
-                        ),
-                        const Gap(AppSizes.spaceXs),
-                        DropdownButtonFormField<int>(
-                          initialValue: cubit.month,
-                          decoration: const InputDecoration(
-                            border: OutlineInputBorder(),
-                            isDense: true,
-                            contentPadding: EdgeInsets.symmetric(
-                              horizontal: AppSizes.spaceSm,
-                              vertical: AppSizes.spaceSm,
-                            ),
-                          ),
-                          hint: Text(t.publications.parameters.monthHint),
-                          items: List.generate(12, (index) {
-                            final month = index + 1;
-                            return DropdownMenuItem(
-                              value: month,
-                              child: Text(_getMonthName(context, month)),
-                            );
-                          }),
-                          onChanged: (value) {
-                            context.read<PublicationsCubit>().setMonth(value);
-                          },
-                        ),
-                      ],
+                      hint: Text(t.publications.parameters.monthHint),
+                      items: List.generate(12, (index) {
+                        final month = index + 1;
+                        return DropdownMenuItem(
+                          value: month,
+                          child: Text(_getMonthName(context, month)),
+                        );
+                      }),
+                      onChanged: (value) {
+                        context.read<PublicationsCubit>().setMonth(value);
+                      },
                     ),
                   ),
-                  const Gap(AppSizes.spaceSm),
-                  // Year selector
-                  Expanded(
-                    child: Column(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: [
-                        Text(
-                          t.publications.parameters.year,
-                          style: Theme.of(context).textTheme.labelMedium
-                              ?.copyWith(fontWeight: FontWeight.w500),
+                ),
+                const Gap(AppSizes.spaceSm),
+                // Year selector
+                Expanded(
+                  child: ParameterField(
+                    label: t.publications.parameters.year,
+                    child: DropdownButtonFormField<int>(
+                      initialValue: cubit.year,
+                      decoration: const InputDecoration(
+                        border: OutlineInputBorder(),
+                        isDense: true,
+                        contentPadding: EdgeInsets.symmetric(
+                          horizontal: AppSizes.spaceSm,
+                          vertical: AppSizes.spaceSm,
                         ),
-                        const Gap(AppSizes.spaceXs),
-                        DropdownButtonFormField<int>(
-                          initialValue: cubit.year,
-                          decoration: const InputDecoration(
-                            border: OutlineInputBorder(),
-                            isDense: true,
-                            contentPadding: EdgeInsets.symmetric(
-                              horizontal: AppSizes.spaceSm,
-                              vertical: AppSizes.spaceSm,
-                            ),
-                          ),
-                          hint: Text(t.publications.parameters.yearHint),
-                          items: _generateYearItems(),
-                          onChanged: (value) {
-                            context.read<PublicationsCubit>().setYear(value);
-                          },
-                        ),
-                      ],
+                      ),
+                      hint: Text(t.publications.parameters.yearHint),
+                      items: _generateYearItems(),
+                      onChanged: (value) {
+                        context.read<PublicationsCubit>().setYear(value);
+                      },
                     ),
-                  ),
-                ],
-              ),
-
-              // Clear filters button
-              if (cubit.keyword != null ||
-                  cubit.month != null ||
-                  cubit.year != null) ...[
-                const Gap(AppSizes.spaceMd),
-                SizedBox(
-                  width: double.infinity,
-                  child: OutlinedButton.icon(
-                    onPressed: () {
-                      keywordController.clear();
-                      context.read<PublicationsCubit>().clearFilters();
-                    },
-                    icon: const Icon(Icons.clear, size: 16),
-                    label: Text(t.publications.parameters.clearButton),
                   ),
                 ),
               ],
+            ),
+            // Clear filters button
+            if (cubit.keyword != null ||
+                cubit.month != null ||
+                cubit.year != null) ...[
+              const Gap(AppSizes.spaceMd),
+              SizedBox(
+                width: double.infinity,
+                child: OutlinedButton.icon(
+                  onPressed: () {
+                    keywordController.clear();
+                    context.read<PublicationsCubit>().clearFilters();
+                  },
+                  icon: const Icon(Icons.clear, size: 16),
+                  label: Text(t.publications.parameters.clearButton),
+                ),
+              ),
             ],
-          ),
+          ],
         );
       },
     );

--- a/app/example/lib/features/sdg_indicators/presentation/widgets/sdg_indicators_parameters_panel.dart
+++ b/app/example/lib/features/sdg_indicators/presentation/widgets/sdg_indicators_parameters_panel.dart
@@ -5,6 +5,7 @@ import 'package:stadata_example/core/constants/app_sizes.dart';
 import 'package:stadata_example/core/generated/strings.g.dart';
 import 'package:stadata_example/features/sdg_indicators/presentation/cubit/sdg_indicators_cubit.dart';
 import 'package:stadata_example/shared/cubit/base_cubit.dart';
+import 'package:stadata_example/shared/widgets/parameters_panel.dart';
 import 'package:stadata_flutter_sdk/stadata_flutter_sdk.dart';
 
 class SdgIndicatorsParametersPanel extends StatelessWidget {
@@ -25,173 +26,112 @@ class SdgIndicatorsParametersPanel extends StatelessWidget {
       builder: (context, state) {
         final cubit = context.read<SdgIndicatorsCubit>();
 
-        return Container(
-          width: double.infinity,
-          padding: const EdgeInsets.all(AppSizes.spaceMd),
-          decoration: BoxDecoration(
-            color: Colors.white,
-            borderRadius: BorderRadius.circular(8),
-            border: Border.all(
-              color: Theme.of(
-                context,
-              ).colorScheme.outline.withValues(alpha: 0.3),
+        return ParametersPanel(
+          title: t.sdgIndicators.parameters.title,
+          children: [
+            // Domain Input
+            ParameterField(
+              label: '${t.sdgIndicators.parameters.domain} *',
+              child: TextFormField(
+                controller: domainController,
+                decoration: InputDecoration(
+                  border: const OutlineInputBorder(),
+                  hintText: t.sdgIndicators.parameters.domainHint,
+                  isDense: true,
+                  contentPadding: const EdgeInsets.symmetric(
+                    horizontal: AppSizes.spaceSm,
+                    vertical: AppSizes.spaceSm,
+                  ),
+                ),
+                keyboardType: TextInputType.number,
+                onChanged: cubit.changeDomain,
+              ),
             ),
-          ),
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              Row(
-                children: [
-                  Icon(
-                    Icons.settings,
-                    size: 16,
-                    color: Theme.of(context).colorScheme.primary,
+            const Gap(AppSizes.spaceMd),
+            // Goal Dropdown
+            ParameterField(
+              label: t.sdgIndicators.parameters.goal,
+              child: DropdownButtonFormField<SdgGoalNumber>(
+                initialValue: cubit.currentGoal,
+                decoration: const InputDecoration(
+                  border: OutlineInputBorder(),
+                  isDense: true,
+                  contentPadding: EdgeInsets.symmetric(
+                    horizontal: AppSizes.spaceSm,
+                    vertical: AppSizes.spaceSm,
                   ),
-                  const Gap(AppSizes.spaceXs),
-                  Text(
-                    t.sdgIndicators.parameters.title,
-                    style: Theme.of(context).textTheme.titleSmall?.copyWith(
-                      fontWeight: FontWeight.w600,
-                    ),
-                  ),
-                ],
-              ),
-              const Gap(AppSizes.spaceMd),
-
-              // Domain Input
-              _ParameterField(
-                label: '${t.sdgIndicators.parameters.domain} *',
-                child: TextFormField(
-                  controller: domainController,
-                  decoration: InputDecoration(
-                    border: const OutlineInputBorder(),
-                    hintText: t.sdgIndicators.parameters.domainHint,
-                    isDense: true,
-                    contentPadding: const EdgeInsets.symmetric(
-                      horizontal: AppSizes.spaceSm,
-                      vertical: AppSizes.spaceSm,
-                    ),
-                  ),
-                  keyboardType: TextInputType.number,
-                  onChanged: cubit.changeDomain,
                 ),
+                hint: Text(t.sdgIndicators.parameters.goalHint),
+                menuMaxHeight: 300,
+                isExpanded: true,
+                items:
+                    SdgGoalNumber.values.map((goal) {
+                      return DropdownMenuItem<SdgGoalNumber>(
+                        value: goal,
+                        child: Text('Goal ${goal.value}'),
+                      );
+                    }).toList(),
+                onChanged: (value) {
+                  if (value != null) cubit.setGoal(value);
+                },
               ),
-
-              const Gap(AppSizes.spaceMd),
-
-              // Goal Dropdown
-              _ParameterField(
-                label: t.sdgIndicators.parameters.goal,
-                child: DropdownButtonFormField<SdgGoalNumber>(
-                  initialValue: cubit.currentGoal,
-                  decoration: const InputDecoration(
-                    border: OutlineInputBorder(),
-                    isDense: true,
-                    contentPadding: EdgeInsets.symmetric(
-                      horizontal: AppSizes.spaceSm,
-                      vertical: AppSizes.spaceSm,
-                    ),
+            ),
+            const Gap(AppSizes.spaceMd),
+            // Page Input
+            ParameterField(
+              label: t.sdgIndicators.parameters.page,
+              child: TextFormField(
+                controller: pageController,
+                decoration: const InputDecoration(
+                  border: OutlineInputBorder(),
+                  hintText: 'Enter page number',
+                  isDense: true,
+                  contentPadding: EdgeInsets.symmetric(
+                    horizontal: AppSizes.spaceSm,
+                    vertical: AppSizes.spaceSm,
                   ),
-                  hint: Text(t.sdgIndicators.parameters.goalHint),
-                  menuMaxHeight: 300,
-                  isExpanded: true,
-                  items:
-                      SdgGoalNumber.values.map((goal) {
-                        return DropdownMenuItem<SdgGoalNumber>(
-                          value: goal,
-                          child: Text('Goal ${goal.value}'),
-                        );
-                      }).toList(),
-                  onChanged: (value) {
-                    if (value != null) cubit.setGoal(value);
-                  },
                 ),
+                keyboardType: TextInputType.number,
+                textAlign: TextAlign.center,
+                onChanged: (value) {
+                  final p = int.tryParse(value);
+                  if (p != null && p > 0) cubit.page = p;
+                },
               ),
-
-              const Gap(AppSizes.spaceMd),
-
-              // Page Input
-              _ParameterField(
-                label: t.sdgIndicators.parameters.page,
-                child: TextFormField(
-                  controller: pageController,
-                  decoration: const InputDecoration(
-                    border: OutlineInputBorder(),
-                    hintText: 'Enter page number',
-                    isDense: true,
-                    contentPadding: EdgeInsets.symmetric(
-                      horizontal: AppSizes.spaceSm,
-                      vertical: AppSizes.spaceSm,
-                    ),
+            ),
+            const Gap(AppSizes.spaceMd),
+            // Language Selector
+            ParameterField(
+              label: t.sdgIndicators.parameters.language,
+              child: DropdownButtonFormField<DataLanguage>(
+                initialValue: cubit.currentLanguage,
+                decoration: const InputDecoration(
+                  border: OutlineInputBorder(),
+                  isDense: true,
+                  contentPadding: EdgeInsets.symmetric(
+                    horizontal: AppSizes.spaceSm,
+                    vertical: AppSizes.spaceSm,
                   ),
-                  keyboardType: TextInputType.number,
-                  textAlign: TextAlign.center,
-                  onChanged: (value) {
-                    final p = int.tryParse(value);
-                    if (p != null && p > 0) cubit.page = p;
-                  },
                 ),
+                items:
+                    DataLanguage.values.map((language) {
+                      return DropdownMenuItem<DataLanguage>(
+                        value: language,
+                        child: Text(
+                          language == DataLanguage.id
+                              ? 'Indonesian'
+                              : 'English',
+                        ),
+                      );
+                    }).toList(),
+                onChanged: (value) {
+                  if (value != null) cubit.changeLanguage(value);
+                },
               ),
-
-              const Gap(AppSizes.spaceMd),
-
-              // Language Selector
-              _ParameterField(
-                label: t.sdgIndicators.parameters.language,
-                child: DropdownButtonFormField<DataLanguage>(
-                  initialValue: cubit.currentLanguage,
-                  decoration: const InputDecoration(
-                    border: OutlineInputBorder(),
-                    isDense: true,
-                    contentPadding: EdgeInsets.symmetric(
-                      horizontal: AppSizes.spaceSm,
-                      vertical: AppSizes.spaceSm,
-                    ),
-                  ),
-                  items:
-                      DataLanguage.values.map((language) {
-                        return DropdownMenuItem<DataLanguage>(
-                          value: language,
-                          child: Text(
-                            language == DataLanguage.id
-                                ? 'Indonesian'
-                                : 'English',
-                          ),
-                        );
-                      }).toList(),
-                  onChanged: (value) {
-                    if (value != null) cubit.changeLanguage(value);
-                  },
-                ),
-              ),
-            ],
-          ),
+            ),
+          ],
         );
       },
-    );
-  }
-}
-
-class _ParameterField extends StatelessWidget {
-  const _ParameterField({required this.label, required this.child});
-
-  final String label;
-  final Widget child;
-
-  @override
-  Widget build(BuildContext context) {
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        Text(
-          label,
-          style: Theme.of(context).textTheme.labelMedium?.copyWith(
-            fontWeight: FontWeight.w500,
-          ),
-        ),
-        const Gap(AppSizes.spaceXs),
-        child,
-      ],
     );
   }
 }

--- a/app/example/lib/features/static_tables/presentation/widgets/static_tables_parameters_panel.dart
+++ b/app/example/lib/features/static_tables/presentation/widgets/static_tables_parameters_panel.dart
@@ -5,6 +5,7 @@ import 'package:gap/gap.dart';
 import 'package:stadata_example/core/constants/app_sizes.dart';
 import 'package:stadata_example/features/static_tables/presentation/cubit/static_tables_cubit.dart';
 import 'package:stadata_example/shared/cubit/base_cubit.dart';
+import 'package:stadata_example/shared/widgets/parameters_panel.dart';
 import 'package:stadata_flutter_sdk/stadata_flutter_sdk.dart';
 
 /// A reusable parameters panel widget for static tables configuration
@@ -24,244 +25,160 @@ class StaticTablesParametersPanel extends StatelessWidget {
       builder: (context, state) {
         final cubit = context.read<StaticTablesCubit>();
 
-        return Container(
-          width: double.infinity,
-          padding: const EdgeInsets.all(AppSizes.spaceMd),
-          decoration: BoxDecoration(
-            color: Colors.white,
-            borderRadius: BorderRadius.circular(8),
-            border: Border.all(
-              color: Theme.of(
-                context,
-              ).colorScheme.outline.withValues(alpha: 0.3),
+        return ParametersPanel(
+          title: 'Parameters',
+          children: [
+            // Domain Input (required)
+            ParameterField(
+              label: 'Domain *',
+              child: TextFormField(
+                controller: domainController,
+                decoration: const InputDecoration(
+                  border: OutlineInputBorder(),
+                  hintText: 'e.g., 7200',
+                  isDense: true,
+                  contentPadding: EdgeInsets.symmetric(
+                    horizontal: AppSizes.spaceSm,
+                    vertical: AppSizes.spaceSm,
+                  ),
+                ),
+                keyboardType: TextInputType.number,
+                inputFormatters: [FilteringTextInputFormatter.digitsOnly],
+                maxLength: 4,
+                onChanged: (value) {
+                  context.read<StaticTablesCubit>().setDomain(
+                    value.isEmpty ? null : value,
+                  );
+                },
+              ),
             ),
-          ),
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              // Header
-              Row(
-                children: [
-                  Icon(
-                    Icons.settings,
-                    size: 16,
-                    color: Theme.of(context).colorScheme.primary,
+            const Gap(AppSizes.spaceMd),
+            // Language Selector
+            ParameterField(
+              label: 'Language',
+              child: DropdownButtonFormField<DataLanguage>(
+                initialValue: cubit.currentLanguage,
+                decoration: const InputDecoration(
+                  border: OutlineInputBorder(),
+                  isDense: true,
+                  contentPadding: EdgeInsets.symmetric(
+                    horizontal: AppSizes.spaceSm,
+                    vertical: AppSizes.spaceSm,
                   ),
-                  const Gap(AppSizes.spaceXs),
-                  Text(
-                    'Parameters',
-                    style: Theme.of(context).textTheme.titleSmall?.copyWith(
-                      fontWeight: FontWeight.w600,
-                    ),
-                  ),
-                ],
-              ),
-              const Gap(AppSizes.spaceMd),
-
-              // Domain Input (required)
-              Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  Text(
-                    'Domain *',
-                    style: Theme.of(context).textTheme.labelMedium?.copyWith(
-                      fontWeight: FontWeight.w500,
-                    ),
-                  ),
-                  const Gap(AppSizes.spaceXs),
-                  TextFormField(
-                    controller: domainController,
-                    decoration: const InputDecoration(
-                      border: OutlineInputBorder(),
-                      hintText: 'e.g., 7200',
-                      isDense: true,
-                      contentPadding: EdgeInsets.symmetric(
-                        horizontal: AppSizes.spaceSm,
-                        vertical: AppSizes.spaceSm,
-                      ),
-                    ),
-                    keyboardType: TextInputType.number,
-                    inputFormatters: [FilteringTextInputFormatter.digitsOnly],
-                    maxLength: 4,
-                    onChanged: (value) {
-                      context.read<StaticTablesCubit>().setDomain(
-                        value.isEmpty ? null : value,
+                ),
+                items:
+                    DataLanguage.values.map((lang) {
+                      return DropdownMenuItem(
+                        value: lang,
+                        child: Text(
+                          lang == DataLanguage.id ? 'Indonesian' : 'English',
+                        ),
                       );
-                    },
-                  ),
-                ],
+                    }).toList(),
+                onChanged: (value) {
+                  if (value != null) {
+                    context.read<StaticTablesCubit>().changeLanguage(value);
+                  }
+                },
               ),
-
-              const Gap(AppSizes.spaceMd),
-
-              // Language Selector
-              Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  Text(
-                    'Language',
-                    style: Theme.of(context).textTheme.labelMedium?.copyWith(
-                      fontWeight: FontWeight.w500,
-                    ),
+            ),
+            const Gap(AppSizes.spaceMd),
+            // Keyword Input (optional)
+            ParameterField(
+              label: 'Keyword',
+              child: TextFormField(
+                controller: keywordController,
+                decoration: const InputDecoration(
+                  border: OutlineInputBorder(),
+                  hintText: 'Search keyword (optional)',
+                  isDense: true,
+                  contentPadding: EdgeInsets.symmetric(
+                    horizontal: AppSizes.spaceSm,
+                    vertical: AppSizes.spaceSm,
                   ),
-                  const Gap(AppSizes.spaceXs),
-                  DropdownButtonFormField<DataLanguage>(
-                    initialValue: cubit.currentLanguage,
-                    decoration: const InputDecoration(
-                      border: OutlineInputBorder(),
-                      isDense: true,
-                      contentPadding: EdgeInsets.symmetric(
-                        horizontal: AppSizes.spaceSm,
-                        vertical: AppSizes.spaceSm,
+                ),
+                onChanged: (value) {
+                  context.read<StaticTablesCubit>().setKeyword(
+                    value.isEmpty ? null : value,
+                  );
+                },
+              ),
+            ),
+            const Gap(AppSizes.spaceMd),
+            // Month and Year filters
+            Row(
+              children: [
+                // Month selector
+                Expanded(
+                  child: ParameterField(
+                    label: 'Month',
+                    child: DropdownButtonFormField<int>(
+                      initialValue: cubit.month,
+                      decoration: const InputDecoration(
+                        border: OutlineInputBorder(),
+                        isDense: true,
+                        contentPadding: EdgeInsets.symmetric(
+                          horizontal: AppSizes.spaceSm,
+                          vertical: AppSizes.spaceSm,
+                        ),
                       ),
-                    ),
-                    items:
-                        DataLanguage.values.map((lang) {
-                          return DropdownMenuItem(
-                            value: lang,
-                            child: Text(
-                              lang == DataLanguage.id
-                                  ? 'Indonesian'
-                                  : 'English',
-                            ),
-                          );
-                        }).toList(),
-                    onChanged: (value) {
-                      if (value != null) {
-                        context.read<StaticTablesCubit>().changeLanguage(value);
-                      }
-                    },
-                  ),
-                ],
-              ),
-
-              const Gap(AppSizes.spaceMd),
-
-              // Keyword Input (optional)
-              Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  Text(
-                    'Keyword',
-                    style: Theme.of(context).textTheme.labelMedium?.copyWith(
-                      fontWeight: FontWeight.w500,
+                      hint: const Text('All'),
+                      items: List.generate(12, (index) {
+                        final month = index + 1;
+                        return DropdownMenuItem(
+                          value: month,
+                          child: Text(_getMonthName(month)),
+                        );
+                      }),
+                      onChanged: (value) {
+                        context.read<StaticTablesCubit>().setMonth(value);
+                      },
                     ),
                   ),
-                  const Gap(AppSizes.spaceXs),
-                  TextFormField(
-                    controller: keywordController,
-                    decoration: const InputDecoration(
-                      border: OutlineInputBorder(),
-                      hintText: 'Search keyword (optional)',
-                      isDense: true,
-                      contentPadding: EdgeInsets.symmetric(
-                        horizontal: AppSizes.spaceSm,
-                        vertical: AppSizes.spaceSm,
+                ),
+                const Gap(AppSizes.spaceSm),
+                // Year selector
+                Expanded(
+                  child: ParameterField(
+                    label: 'Year',
+                    child: DropdownButtonFormField<int>(
+                      initialValue: cubit.year,
+                      decoration: const InputDecoration(
+                        border: OutlineInputBorder(),
+                        isDense: true,
+                        contentPadding: EdgeInsets.symmetric(
+                          horizontal: AppSizes.spaceSm,
+                          vertical: AppSizes.spaceSm,
+                        ),
                       ),
+                      hint: const Text('All'),
+                      items: _generateYearItems(),
+                      onChanged: (value) {
+                        context.read<StaticTablesCubit>().setYear(value);
+                      },
                     ),
-                    onChanged: (value) {
-                      context.read<StaticTablesCubit>().setKeyword(
-                        value.isEmpty ? null : value,
-                      );
-                    },
-                  ),
-                ],
-              ),
-
-              const Gap(AppSizes.spaceMd),
-
-              // Month and Year filters
-              Row(
-                children: [
-                  // Month selector
-                  Expanded(
-                    child: Column(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: [
-                        Text(
-                          'Month',
-                          style: Theme.of(context).textTheme.labelMedium
-                              ?.copyWith(fontWeight: FontWeight.w500),
-                        ),
-                        const Gap(AppSizes.spaceXs),
-                        DropdownButtonFormField<int>(
-                          initialValue: cubit.month,
-                          decoration: const InputDecoration(
-                            border: OutlineInputBorder(),
-                            isDense: true,
-                            contentPadding: EdgeInsets.symmetric(
-                              horizontal: AppSizes.spaceSm,
-                              vertical: AppSizes.spaceSm,
-                            ),
-                          ),
-                          hint: const Text('All'),
-                          items: List.generate(12, (index) {
-                            final month = index + 1;
-                            return DropdownMenuItem(
-                              value: month,
-                              child: Text(_getMonthName(month)),
-                            );
-                          }),
-                          onChanged: (value) {
-                            context.read<StaticTablesCubit>().setMonth(value);
-                          },
-                        ),
-                      ],
-                    ),
-                  ),
-                  const Gap(AppSizes.spaceSm),
-                  // Year selector
-                  Expanded(
-                    child: Column(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: [
-                        Text(
-                          'Year',
-                          style: Theme.of(context).textTheme.labelMedium
-                              ?.copyWith(fontWeight: FontWeight.w500),
-                        ),
-                        const Gap(AppSizes.spaceXs),
-                        DropdownButtonFormField<int>(
-                          initialValue: cubit.year,
-                          decoration: const InputDecoration(
-                            border: OutlineInputBorder(),
-                            isDense: true,
-                            contentPadding: EdgeInsets.symmetric(
-                              horizontal: AppSizes.spaceSm,
-                              vertical: AppSizes.spaceSm,
-                            ),
-                          ),
-                          hint: const Text('All'),
-                          items: _generateYearItems(),
-                          onChanged: (value) {
-                            context.read<StaticTablesCubit>().setYear(value);
-                          },
-                        ),
-                      ],
-                    ),
-                  ),
-                ],
-              ),
-
-              // Clear filters button
-              if (cubit.keyword != null ||
-                  cubit.month != null ||
-                  cubit.year != null) ...[
-                const Gap(AppSizes.spaceMd),
-                SizedBox(
-                  width: double.infinity,
-                  child: OutlinedButton.icon(
-                    onPressed: () {
-                      keywordController.clear();
-                      context.read<StaticTablesCubit>().clearFilters();
-                    },
-                    icon: const Icon(Icons.clear, size: 16),
-                    label: const Text('Clear Filters'),
                   ),
                 ),
               ],
+            ),
+            // Clear filters button
+            if (cubit.keyword != null ||
+                cubit.month != null ||
+                cubit.year != null) ...[
+              const Gap(AppSizes.spaceMd),
+              SizedBox(
+                width: double.infinity,
+                child: OutlinedButton.icon(
+                  onPressed: () {
+                    keywordController.clear();
+                    context.read<StaticTablesCubit>().clearFilters();
+                  },
+                  icon: const Icon(Icons.clear, size: 16),
+                  label: const Text('Clear Filters'),
+                ),
+              ),
             ],
-          ),
+          ],
         );
       },
     );

--- a/app/example/lib/features/statistical_classifications/presentation/widgets/statistical_classifications_parameters_panel.dart
+++ b/app/example/lib/features/statistical_classifications/presentation/widgets/statistical_classifications_parameters_panel.dart
@@ -5,6 +5,7 @@ import 'package:stadata_example/core/constants/app_sizes.dart';
 import 'package:stadata_example/core/generated/strings.g.dart';
 import 'package:stadata_example/features/statistical_classifications/presentation/cubit/statistical_classifications_cubit.dart';
 import 'package:stadata_example/shared/cubit/base_cubit.dart';
+import 'package:stadata_example/shared/widgets/parameters_panel.dart';
 import 'package:stadata_flutter_sdk/stadata_flutter_sdk.dart';
 
 class StatisticalClassificationsParametersPanel extends StatefulWidget {
@@ -25,97 +26,51 @@ class _StatisticalClassificationsParametersPanelState
       builder: (context, state) {
         final cubit = context.read<StatisticalClassificationsCubit>();
 
-        return Container(
-          width: double.infinity,
-          padding: const EdgeInsets.all(AppSizes.spaceMd),
-          decoration: BoxDecoration(
-            color: Colors.white,
-            borderRadius: BorderRadius.circular(8),
-            border: Border.all(
-              color: Theme.of(
-                context,
-              ).colorScheme.outline.withValues(alpha: 0.3),
+        return ParametersPanel(
+          title: t.statisticalClassifications.parameters.title,
+          children: [
+            // Category dropdown (KBLI/KBKI)
+            ParameterField(
+              label: t.statisticalClassifications.parameters.category,
+              child: DropdownButtonFormField<ClassificationCategory>(
+                initialValue: cubit.category,
+                decoration: InputDecoration(
+                  border: const OutlineInputBorder(),
+                  hintText:
+                      t.statisticalClassifications.parameters.categoryHint,
+                  isDense: true,
+                  contentPadding: const EdgeInsets.symmetric(
+                    horizontal: AppSizes.spaceSm,
+                    vertical: AppSizes.spaceSm,
+                  ),
+                ),
+                items:
+                    ClassificationCategory.values.map((category) {
+                      final label = switch (category) {
+                        ClassificationCategory.kbli => 'KBLI',
+                        ClassificationCategory.kbki => 'KBKI',
+                      };
+                      return DropdownMenuItem(
+                        value: category,
+                        child: Text(label),
+                      );
+                    }).toList(),
+                onChanged: (value) {
+                  if (value != null) {
+                    context.read<StatisticalClassificationsCubit>().setCategory(
+                      value,
+                    );
+                  }
+                },
+              ),
             ),
-          ),
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              Row(
-                children: [
-                  Icon(
-                    Icons.settings,
-                    size: 16,
-                    color: Theme.of(context).colorScheme.primary,
-                  ),
-                  const Gap(AppSizes.spaceXs),
-                  Text(
-                    t.statisticalClassifications.parameters.title,
-                    style: Theme.of(context).textTheme.titleSmall?.copyWith(
-                      fontWeight: FontWeight.w600,
-                    ),
-                  ),
-                ],
-              ),
-              const Gap(AppSizes.spaceMd),
-
-              // Category dropdown (KBLI/KBKI)
-              Column(
+            const Gap(AppSizes.spaceMd),
+            // Type dropdown (dynamic based on category)
+            ParameterField(
+              label: t.statisticalClassifications.parameters.type,
+              child: Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
-                  Text(
-                    t.statisticalClassifications.parameters.category,
-                    style: Theme.of(context).textTheme.labelMedium?.copyWith(
-                      fontWeight: FontWeight.w500,
-                    ),
-                  ),
-                  const Gap(AppSizes.spaceXs),
-                  DropdownButtonFormField<ClassificationCategory>(
-                    initialValue: cubit.category,
-                    decoration: InputDecoration(
-                      border: const OutlineInputBorder(),
-                      hintText:
-                          t.statisticalClassifications.parameters.categoryHint,
-                      isDense: true,
-                      contentPadding: const EdgeInsets.symmetric(
-                        horizontal: AppSizes.spaceSm,
-                        vertical: AppSizes.spaceSm,
-                      ),
-                    ),
-                    items:
-                        ClassificationCategory.values.map((category) {
-                          final label = switch (category) {
-                            ClassificationCategory.kbli => 'KBLI',
-                            ClassificationCategory.kbki => 'KBKI',
-                          };
-                          return DropdownMenuItem(
-                            value: category,
-                            child: Text(label),
-                          );
-                        }).toList(),
-                    onChanged: (value) {
-                      if (value != null) {
-                        context
-                            .read<StatisticalClassificationsCubit>()
-                            .setCategory(value);
-                      }
-                    },
-                  ),
-                ],
-              ),
-
-              const Gap(AppSizes.spaceMd),
-
-              // Type dropdown (dynamic based on category)
-              Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  Text(
-                    t.statisticalClassifications.parameters.type,
-                    style: Theme.of(context).textTheme.labelMedium?.copyWith(
-                      fontWeight: FontWeight.w500,
-                    ),
-                  ),
-                  const Gap(AppSizes.spaceXs),
                   if (cubit.category == ClassificationCategory.kbli)
                     DropdownButtonFormField<KBLIType>(
                       initialValue: cubit.type as KBLIType,
@@ -184,20 +139,14 @@ class _StatisticalClassificationsParametersPanelState
                     ),
                 ],
               ),
-
-              const Gap(AppSizes.spaceMd),
-
-              // Level dropdown (optional, dynamic based on category)
-              Column(
+            ),
+            const Gap(AppSizes.spaceMd),
+            // Level dropdown (optional, dynamic based on category)
+            ParameterField(
+              label: t.statisticalClassifications.parameters.level,
+              child: Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
-                  Text(
-                    t.statisticalClassifications.parameters.level,
-                    style: Theme.of(context).textTheme.labelMedium?.copyWith(
-                      fontWeight: FontWeight.w500,
-                    ),
-                  ),
-                  const Gap(AppSizes.spaceXs),
                   if (cubit.category == ClassificationCategory.kbli)
                     DropdownButtonFormField<KBLILevel?>(
                       initialValue: cubit.level as KBLILevel?,
@@ -295,53 +244,42 @@ class _StatisticalClassificationsParametersPanelState
                     ),
                 ],
               ),
-
-              const Gap(AppSizes.spaceMd),
-
-              // Language dropdown
-              Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  Text(
-                    t.statisticalClassifications.parameters.language,
-                    style: Theme.of(context).textTheme.labelMedium?.copyWith(
-                      fontWeight: FontWeight.w500,
-                    ),
+            ),
+            const Gap(AppSizes.spaceMd),
+            // Language dropdown
+            ParameterField(
+              label: t.statisticalClassifications.parameters.language,
+              child: DropdownButtonFormField<DataLanguage>(
+                initialValue: cubit.currentLanguage,
+                decoration: const InputDecoration(
+                  border: OutlineInputBorder(),
+                  isDense: true,
+                  contentPadding: EdgeInsets.symmetric(
+                    horizontal: AppSizes.spaceSm,
+                    vertical: AppSizes.spaceSm,
                   ),
-                  const Gap(AppSizes.spaceXs),
-                  DropdownButtonFormField<DataLanguage>(
-                    initialValue: cubit.currentLanguage,
-                    decoration: const InputDecoration(
-                      border: OutlineInputBorder(),
-                      isDense: true,
-                      contentPadding: EdgeInsets.symmetric(
-                        horizontal: AppSizes.spaceSm,
-                        vertical: AppSizes.spaceSm,
-                      ),
-                    ),
-                    items:
-                        DataLanguage.values.map((lang) {
-                          return DropdownMenuItem(
-                            value: lang,
-                            child: Text(
-                              lang == DataLanguage.id
-                                  ? t.instructions.languageLabels.indonesian
-                                  : t.instructions.languageLabels.english,
-                            ),
-                          );
-                        }).toList(),
-                    onChanged: (value) {
-                      if (value != null) {
-                        context
-                            .read<StatisticalClassificationsCubit>()
-                            .changeLanguage(value);
-                      }
-                    },
-                  ),
-                ],
+                ),
+                items:
+                    DataLanguage.values.map((lang) {
+                      return DropdownMenuItem(
+                        value: lang,
+                        child: Text(
+                          lang == DataLanguage.id
+                              ? t.instructions.languageLabels.indonesian
+                              : t.instructions.languageLabels.english,
+                        ),
+                      );
+                    }).toList(),
+                onChanged: (value) {
+                  if (value != null) {
+                    context
+                        .read<StatisticalClassificationsCubit>()
+                        .changeLanguage(value);
+                  }
+                },
               ),
-            ],
-          ),
+            ),
+          ],
         );
       },
     );

--- a/app/example/lib/features/strategic_indicators/presentation/widgets/strategic_indicators_parameters_panel.dart
+++ b/app/example/lib/features/strategic_indicators/presentation/widgets/strategic_indicators_parameters_panel.dart
@@ -7,6 +7,7 @@ import 'package:stadata_example/core/constants/app_sizes.dart';
 import 'package:stadata_example/core/generated/strings.g.dart';
 import 'package:stadata_example/features/strategic_indicators/presentation/cubit/strategic_indicators_cubit.dart';
 import 'package:stadata_example/shared/cubit/base_cubit.dart';
+import 'package:stadata_example/shared/widgets/parameters_panel.dart';
 import 'package:stadata_flutter_sdk/stadata_flutter_sdk.dart';
 
 class StrategicIndicatorsParametersPanel extends StatefulWidget {
@@ -32,206 +33,144 @@ class _StrategicIndicatorsParametersPanelState
       builder: (context, state) {
         final cubit = context.read<StrategicIndicatorsCubit>();
 
-        return Container(
-          width: double.infinity,
-          padding: const EdgeInsets.all(AppSizes.spaceMd),
-          decoration: BoxDecoration(
-            color: Colors.white,
-            borderRadius: BorderRadius.circular(8),
-            border: Border.all(
-              color: Theme.of(
-                context,
-              ).colorScheme.outline.withValues(alpha: 0.3),
+        return ParametersPanel(
+          title: t.strategicIndicators.parameters.title,
+          children: [
+            // Domain field
+            ParameterField(
+              label: t.strategicIndicators.parameters.domain,
+              child: TextFormField(
+                controller: widget.domainController,
+                decoration: InputDecoration(
+                  border: const OutlineInputBorder(),
+                  hintText: t.strategicIndicators.parameters.domainHint,
+                  isDense: true,
+                  contentPadding: const EdgeInsets.symmetric(
+                    horizontal: AppSizes.spaceSm,
+                    vertical: AppSizes.spaceSm,
+                  ),
+                ),
+                keyboardType: TextInputType.number,
+                inputFormatters: [FilteringTextInputFormatter.digitsOnly],
+                maxLength: 4,
+                onChanged: (value) {
+                  context.read<StrategicIndicatorsCubit>().setDomain(
+                    value.isEmpty ? null : value,
+                  );
+                },
+              ),
             ),
-          ),
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              Row(
-                children: [
-                  Icon(
-                    Icons.settings,
-                    size: 16,
-                    color: Theme.of(context).colorScheme.primary,
-                  ),
-                  const Gap(AppSizes.spaceXs),
-                  Text(
-                    t.strategicIndicators.parameters.title,
-                    style: Theme.of(context).textTheme.titleSmall?.copyWith(
-                      fontWeight: FontWeight.w600,
-                    ),
-                  ),
-                ],
-              ),
-              const Gap(AppSizes.spaceMd),
-
-              // Domain field
-              Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  Text(
-                    t.strategicIndicators.parameters.domain,
-                    style: Theme.of(context).textTheme.labelMedium?.copyWith(
-                      fontWeight: FontWeight.w500,
-                    ),
-                  ),
-                  const Gap(AppSizes.spaceXs),
-                  TextFormField(
-                    controller: widget.domainController,
-                    decoration: InputDecoration(
-                      border: const OutlineInputBorder(),
-                      hintText: t.strategicIndicators.parameters.domainHint,
-                      isDense: true,
-                      contentPadding: const EdgeInsets.symmetric(
-                        horizontal: AppSizes.spaceSm,
-                        vertical: AppSizes.spaceSm,
-                      ),
-                    ),
-                    keyboardType: TextInputType.number,
-                    inputFormatters: [FilteringTextInputFormatter.digitsOnly],
-                    maxLength: 4,
-                    onChanged: (value) {
-                      context.read<StrategicIndicatorsCubit>().setDomain(
-                        value.isEmpty ? null : value,
-                      );
-                    },
-                  ),
-                ],
-              ),
-
-              const Gap(AppSizes.spaceMd),
-
-              // Variable ID dropdown with search and pagination
-              Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  Text(
-                    t.strategicIndicators.parameters.variableID,
-                    style: Theme.of(context).textTheme.labelMedium?.copyWith(
-                      fontWeight: FontWeight.w500,
-                    ),
-                  ),
-                  const Gap(AppSizes.spaceXs),
-                  SearchableDropdown<Variable>.paginated(
-                    requestItemCount: 10,
-                    hintText: Text(
-                      cubit.canLoadVariables
-                          ? t.strategicIndicators.parameters.variableIDHint
-                          : 'Enter domain first (4 digits)',
-                    ),
-                    isEnabled: cubit.canLoadVariables,
-                    paginatedRequest: (page, searchKey) async {
-                      if (!cubit.canLoadVariables) {
-                        return [];
-                      }
-                      final variables = await cubit.fetchVariables(
-                        page: page,
-                        searchText: searchKey,
-                      );
-                      return variables
-                          .map(
-                            (variable) => SearchableDropdownMenuItem<Variable>(
-                              value: variable,
-                              label: '${variable.id} - ${variable.title}',
-                              child: ListTile(
-                                contentPadding: EdgeInsets.zero,
-                                title: Text(
-                                  '${variable.id} - ${variable.title}',
-                                  style: Theme.of(context).textTheme.bodyMedium,
-                                ),
-                                subtitle:
-                                    variable.unit.isNotEmpty
-                                        ? Text(
-                                          'Unit: ${variable.unit}',
-                                          style: Theme.of(
-                                            context,
-                                          ).textTheme.bodySmall?.copyWith(
-                                            color:
-                                                Theme.of(
-                                                  context,
-                                                ).colorScheme.onSurfaceVariant,
-                                          ),
-                                        )
-                                        : null,
-                              ),
+            const Gap(AppSizes.spaceMd),
+            // Variable ID dropdown with search and pagination
+            ParameterField(
+              label: t.strategicIndicators.parameters.variableID,
+              child: SearchableDropdown<Variable>.paginated(
+                requestItemCount: 10,
+                hintText: Text(
+                  cubit.canLoadVariables
+                      ? t.strategicIndicators.parameters.variableIDHint
+                      : 'Enter domain first (4 digits)',
+                ),
+                isEnabled: cubit.canLoadVariables,
+                paginatedRequest: (page, searchKey) async {
+                  if (!cubit.canLoadVariables) {
+                    return [];
+                  }
+                  final variables = await cubit.fetchVariables(
+                    page: page,
+                    searchText: searchKey,
+                  );
+                  return variables
+                      .map(
+                        (variable) => SearchableDropdownMenuItem<Variable>(
+                          value: variable,
+                          label: '${variable.id} - ${variable.title}',
+                          child: ListTile(
+                            contentPadding: EdgeInsets.zero,
+                            title: Text(
+                              '${variable.id} - ${variable.title}',
+                              style: Theme.of(context).textTheme.bodyMedium,
                             ),
-                          )
-                          .toList();
-                    },
-                    onChanged: (variable) {
-                      context.read<StrategicIndicatorsCubit>().setVariableID(
-                        variable?.id,
-                      );
-                    },
-                    backgroundDecoration:
-                        (child) => Card(
-                          margin: EdgeInsets.zero,
-                          elevation: 0,
-                          shape: RoundedRectangleBorder(
-                            borderRadius: BorderRadius.circular(8),
-                            side: BorderSide(
-                              color: Theme.of(context).colorScheme.outline,
-                            ),
-                          ),
-                          child: Padding(
-                            padding: const EdgeInsets.symmetric(
-                              horizontal: AppSizes.spaceSm,
-                              vertical: AppSizes.spaceXs,
-                            ),
-                            child: child,
+                            subtitle:
+                                variable.unit.isNotEmpty
+                                    ? Text(
+                                      'Unit: ${variable.unit}',
+                                      style: Theme.of(
+                                        context,
+                                      ).textTheme.bodySmall?.copyWith(
+                                        color:
+                                            Theme.of(
+                                              context,
+                                            ).colorScheme.onSurfaceVariant,
+                                      ),
+                                    )
+                                    : null,
                           ),
                         ),
-                    margin: EdgeInsets.zero,
-                  ),
-                ],
-              ),
-
-              const Gap(AppSizes.spaceMd),
-
-              // Language dropdown
-              Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  Text(
-                    t.strategicIndicators.parameters.language,
-                    style: Theme.of(context).textTheme.labelMedium?.copyWith(
-                      fontWeight: FontWeight.w500,
-                    ),
-                  ),
-                  const Gap(AppSizes.spaceXs),
-                  DropdownButtonFormField<DataLanguage>(
-                    initialValue: cubit.currentLanguage,
-                    decoration: const InputDecoration(
-                      border: OutlineInputBorder(),
-                      isDense: true,
-                      contentPadding: EdgeInsets.symmetric(
-                        horizontal: AppSizes.spaceSm,
-                        vertical: AppSizes.spaceSm,
+                      )
+                      .toList();
+                },
+                onChanged: (variable) {
+                  context.read<StrategicIndicatorsCubit>().setVariableID(
+                    variable?.id,
+                  );
+                },
+                backgroundDecoration:
+                    (child) => Card(
+                      margin: EdgeInsets.zero,
+                      elevation: 0,
+                      shape: RoundedRectangleBorder(
+                        borderRadius: BorderRadius.circular(8),
+                        side: BorderSide(
+                          color: Theme.of(context).colorScheme.outline,
+                        ),
+                      ),
+                      child: Padding(
+                        padding: const EdgeInsets.symmetric(
+                          horizontal: AppSizes.spaceSm,
+                          vertical: AppSizes.spaceXs,
+                        ),
+                        child: child,
                       ),
                     ),
-                    items:
-                        DataLanguage.values.map((lang) {
-                          return DropdownMenuItem(
-                            value: lang,
-                            child: Text(
-                              lang == DataLanguage.id
-                                  ? t.instructions.languageLabels.indonesian
-                                  : t.instructions.languageLabels.english,
-                            ),
-                          );
-                        }).toList(),
-                    onChanged: (value) {
-                      if (value != null) {
-                        context.read<StrategicIndicatorsCubit>().changeLanguage(
-                          value,
-                        );
-                      }
-                    },
-                  ),
-                ],
+                margin: EdgeInsets.zero,
               ),
-            ],
-          ),
+            ),
+            const Gap(AppSizes.spaceMd),
+            // Language dropdown
+            ParameterField(
+              label: t.strategicIndicators.parameters.language,
+              child: DropdownButtonFormField<DataLanguage>(
+                initialValue: cubit.currentLanguage,
+                decoration: const InputDecoration(
+                  border: OutlineInputBorder(),
+                  isDense: true,
+                  contentPadding: EdgeInsets.symmetric(
+                    horizontal: AppSizes.spaceSm,
+                    vertical: AppSizes.spaceSm,
+                  ),
+                ),
+                items:
+                    DataLanguage.values.map((lang) {
+                      return DropdownMenuItem(
+                        value: lang,
+                        child: Text(
+                          lang == DataLanguage.id
+                              ? t.instructions.languageLabels.indonesian
+                              : t.instructions.languageLabels.english,
+                        ),
+                      );
+                    }).toList(),
+                onChanged: (value) {
+                  if (value != null) {
+                    context.read<StrategicIndicatorsCubit>().changeLanguage(
+                      value,
+                    );
+                  }
+                },
+              ),
+            ),
+          ],
         );
       },
     );

--- a/app/example/lib/features/subject_categories/presentation/widgets/subject_categories_parameters_panel.dart
+++ b/app/example/lib/features/subject_categories/presentation/widgets/subject_categories_parameters_panel.dart
@@ -6,6 +6,7 @@ import 'package:stadata_example/core/constants/app_sizes.dart';
 import 'package:stadata_example/core/generated/strings.g.dart';
 import 'package:stadata_example/features/subject_categories/presentation/cubit/subject_categories_cubit.dart';
 import 'package:stadata_example/shared/cubit/base_cubit.dart';
+import 'package:stadata_example/shared/widgets/parameters_panel.dart';
 import 'package:stadata_flutter_sdk/stadata_flutter_sdk.dart';
 
 class SubjectCategoriesParametersPanel extends StatefulWidget {
@@ -31,119 +32,68 @@ class _SubjectCategoriesParametersPanelState
       builder: (context, state) {
         final cubit = context.read<SubjectCategoriesCubit>();
 
-        return Container(
-          width: double.infinity,
-          padding: const EdgeInsets.all(AppSizes.spaceMd),
-          decoration: BoxDecoration(
-            color: Colors.white,
-            borderRadius: BorderRadius.circular(8),
-            border: Border.all(
-              color: Theme.of(
-                context,
-              ).colorScheme.outline.withValues(alpha: 0.3),
+        return ParametersPanel(
+          title: t.subjectCategories.parameters.title,
+          children: [
+            // Domain field
+            ParameterField(
+              label: t.subjectCategories.parameters.domain,
+              child: TextFormField(
+                controller: widget.domainController,
+                decoration: InputDecoration(
+                  border: const OutlineInputBorder(),
+                  hintText: t.subjectCategories.parameters.domainHint,
+                  isDense: true,
+                  contentPadding: const EdgeInsets.symmetric(
+                    horizontal: AppSizes.spaceSm,
+                    vertical: AppSizes.spaceSm,
+                  ),
+                ),
+                keyboardType: TextInputType.number,
+                inputFormatters: [FilteringTextInputFormatter.digitsOnly],
+                maxLength: 4,
+                onChanged: (value) {
+                  context.read<SubjectCategoriesCubit>().setDomain(
+                    value.isEmpty ? null : value,
+                  );
+                },
+              ),
             ),
-          ),
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              Row(
-                children: [
-                  Icon(
-                    Icons.settings,
-                    size: 16,
-                    color: Theme.of(context).colorScheme.primary,
+            const Gap(AppSizes.spaceMd),
+            // Language dropdown
+            ParameterField(
+              label: t.subjectCategories.parameters.language,
+              child: DropdownButtonFormField<DataLanguage>(
+                initialValue: cubit.currentLanguage,
+                decoration: const InputDecoration(
+                  border: OutlineInputBorder(),
+                  isDense: true,
+                  contentPadding: EdgeInsets.symmetric(
+                    horizontal: AppSizes.spaceSm,
+                    vertical: AppSizes.spaceSm,
                   ),
-                  const Gap(AppSizes.spaceXs),
-                  Text(
-                    t.subjectCategories.parameters.title,
-                    style: Theme.of(context).textTheme.titleSmall?.copyWith(
-                      fontWeight: FontWeight.w600,
-                    ),
-                  ),
-                ],
-              ),
-              const Gap(AppSizes.spaceMd),
-
-              // Domain field
-              Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  Text(
-                    t.subjectCategories.parameters.domain,
-                    style: Theme.of(context).textTheme.labelMedium?.copyWith(
-                      fontWeight: FontWeight.w500,
-                    ),
-                  ),
-                  const Gap(AppSizes.spaceXs),
-                  TextFormField(
-                    controller: widget.domainController,
-                    decoration: InputDecoration(
-                      border: const OutlineInputBorder(),
-                      hintText: t.subjectCategories.parameters.domainHint,
-                      isDense: true,
-                      contentPadding: const EdgeInsets.symmetric(
-                        horizontal: AppSizes.spaceSm,
-                        vertical: AppSizes.spaceSm,
-                      ),
-                    ),
-                    keyboardType: TextInputType.number,
-                    inputFormatters: [FilteringTextInputFormatter.digitsOnly],
-                    maxLength: 4,
-                    onChanged: (value) {
-                      context.read<SubjectCategoriesCubit>().setDomain(
-                        value.isEmpty ? null : value,
+                ),
+                items:
+                    DataLanguage.values.map((lang) {
+                      return DropdownMenuItem(
+                        value: lang,
+                        child: Text(
+                          lang == DataLanguage.id
+                              ? t.instructions.languageLabels.indonesian
+                              : t.instructions.languageLabels.english,
+                        ),
                       );
-                    },
-                  ),
-                ],
+                    }).toList(),
+                onChanged: (value) {
+                  if (value != null) {
+                    context.read<SubjectCategoriesCubit>().changeLanguage(
+                      value,
+                    );
+                  }
+                },
               ),
-
-              const Gap(AppSizes.spaceMd),
-
-              // Language dropdown
-              Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  Text(
-                    t.subjectCategories.parameters.language,
-                    style: Theme.of(context).textTheme.labelMedium?.copyWith(
-                      fontWeight: FontWeight.w500,
-                    ),
-                  ),
-                  const Gap(AppSizes.spaceXs),
-                  DropdownButtonFormField<DataLanguage>(
-                    initialValue: cubit.currentLanguage,
-                    decoration: const InputDecoration(
-                      border: OutlineInputBorder(),
-                      isDense: true,
-                      contentPadding: EdgeInsets.symmetric(
-                        horizontal: AppSizes.spaceSm,
-                        vertical: AppSizes.spaceSm,
-                      ),
-                    ),
-                    items:
-                        DataLanguage.values.map((lang) {
-                          return DropdownMenuItem(
-                            value: lang,
-                            child: Text(
-                              lang == DataLanguage.id
-                                  ? t.instructions.languageLabels.indonesian
-                                  : t.instructions.languageLabels.english,
-                            ),
-                          );
-                        }).toList(),
-                    onChanged: (value) {
-                      if (value != null) {
-                        context.read<SubjectCategoriesCubit>().changeLanguage(
-                          value,
-                        );
-                      }
-                    },
-                  ),
-                ],
-              ),
-            ],
-          ),
+            ),
+          ],
         );
       },
     );

--- a/app/example/lib/features/subjects/presentation/widgets/subjects_parameters_panel.dart
+++ b/app/example/lib/features/subjects/presentation/widgets/subjects_parameters_panel.dart
@@ -8,6 +8,7 @@ import 'package:stadata_example/core/di/injectable.dart';
 import 'package:stadata_example/core/generated/strings.g.dart';
 import 'package:stadata_example/features/subjects/presentation/cubit/subjects_cubit.dart';
 import 'package:stadata_example/shared/cubit/base_cubit.dart';
+import 'package:stadata_example/shared/widgets/parameters_panel.dart';
 import 'package:stadata_flutter_sdk/stadata_flutter_sdk.dart';
 
 class SubjectsParametersPanel extends StatefulWidget {
@@ -31,95 +32,49 @@ class _SubjectsParametersPanelState extends State<SubjectsParametersPanel> {
       builder: (context, state) {
         final cubit = context.read<SubjectsCubit>();
 
-        return Container(
-          width: double.infinity,
-          padding: const EdgeInsets.all(AppSizes.spaceMd),
-          decoration: BoxDecoration(
-            color: Colors.white,
-            borderRadius: BorderRadius.circular(8),
-            border: Border.all(
-              color: Theme.of(
-                context,
-              ).colorScheme.outline.withValues(alpha: 0.3),
+        return ParametersPanel(
+          title: 'Parameters',
+          children: [
+            ParameterField(
+              label: 'Domain *',
+              child: TextFormField(
+                controller: widget.domainController,
+                decoration: const InputDecoration(
+                  border: OutlineInputBorder(),
+                  hintText: 'e.g., 7200',
+                  isDense: true,
+                  contentPadding: EdgeInsets.symmetric(
+                    horizontal: AppSizes.spaceSm,
+                    vertical: AppSizes.spaceSm,
+                  ),
+                ),
+                keyboardType: TextInputType.number,
+                inputFormatters: [FilteringTextInputFormatter.digitsOnly],
+                maxLength: 4,
+                onChanged: (value) {
+                  context.read<SubjectsCubit>().setDomain(
+                    value.isEmpty ? null : value,
+                  );
+                  // Load subject categories when domain changes
+                  if (value.isNotEmpty && value.length >= 4) {
+                    unawaited(
+                      _loadSubjectCategories(value, cubit.currentLanguage),
+                    );
+                  } else {
+                    setState(() {
+                      _subjectCategories = [];
+                      _lastLoadedDomain = null;
+                    });
+                  }
+                },
+              ),
             ),
-          ),
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              Row(
-                children: [
-                  Icon(
-                    Icons.settings,
-                    size: 16,
-                    color: Theme.of(context).colorScheme.primary,
-                  ),
-                  const Gap(AppSizes.spaceXs),
-                  Text(
-                    'Parameters',
-                    style: Theme.of(context).textTheme.titleSmall?.copyWith(
-                      fontWeight: FontWeight.w600,
-                    ),
-                  ),
-                ],
-              ),
-              const Gap(AppSizes.spaceMd),
-
-              Column(
+            const Gap(AppSizes.spaceMd),
+            ParameterField(
+              label: 'Language',
+              child: Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
-                  Text(
-                    'Domain *',
-                    style: Theme.of(context).textTheme.labelMedium?.copyWith(
-                      fontWeight: FontWeight.w500,
-                    ),
-                  ),
-                  const Gap(AppSizes.spaceXs),
-                  TextFormField(
-                    controller: widget.domainController,
-                    decoration: const InputDecoration(
-                      border: OutlineInputBorder(),
-                      hintText: 'e.g., 7200',
-                      isDense: true,
-                      contentPadding: EdgeInsets.symmetric(
-                        horizontal: AppSizes.spaceSm,
-                        vertical: AppSizes.spaceSm,
-                      ),
-                    ),
-                    keyboardType: TextInputType.number,
-                    inputFormatters: [FilteringTextInputFormatter.digitsOnly],
-                    maxLength: 4,
-                    onChanged: (value) {
-                      context.read<SubjectsCubit>().setDomain(
-                        value.isEmpty ? null : value,
-                      );
-                      // Load subject categories when domain changes
-                      if (value.isNotEmpty && value.length >= 4) {
-                        unawaited(
-                          _loadSubjectCategories(value, cubit.currentLanguage),
-                        );
-                      } else {
-                        setState(() {
-                          _subjectCategories = [];
-                          _lastLoadedDomain = null;
-                        });
-                      }
-                    },
-                  ),
-                ],
-              ),
-
-              const Gap(AppSizes.spaceMd),
-
-              Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  Text(
-                    'Language',
-                    style: Theme.of(context).textTheme.labelMedium?.copyWith(
-                      fontWeight: FontWeight.w500,
-                    ),
-                  ),
-                  const Gap(AppSizes.spaceXs),
                   DropdownButtonFormField<DataLanguage>(
                     initialValue: cubit.currentLanguage,
                     decoration: const InputDecoration(
@@ -169,86 +124,84 @@ class _SubjectsParametersPanelState extends State<SubjectsParametersPanel> {
                   ),
                 ],
               ),
-
-              const Gap(AppSizes.spaceMd),
-
-              Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  Row(
-                    children: [
-                      Text(
-                        'Subject Category (Optional)',
-                        style: Theme.of(context).textTheme.labelMedium
-                            ?.copyWith(fontWeight: FontWeight.w500),
+            ),
+            const Gap(AppSizes.spaceMd),
+            Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Row(
+                  children: [
+                    Text(
+                      'Subject Category (Optional)',
+                      style: Theme.of(context).textTheme.labelMedium?.copyWith(
+                        fontWeight: FontWeight.w500,
                       ),
-                      if (_isLoadingCategories) ...[
-                        const Gap(AppSizes.spaceXs),
-                        const SizedBox(
-                          width: 12,
-                          height: 12,
-                          child: CircularProgressIndicator(strokeWidth: 2),
-                        ),
-                      ],
+                    ),
+                    if (_isLoadingCategories) ...[
+                      const Gap(AppSizes.spaceXs),
+                      const SizedBox(
+                        width: 12,
+                        height: 12,
+                        child: CircularProgressIndicator(strokeWidth: 2),
+                      ),
                     ],
-                  ),
-                  const Gap(AppSizes.spaceXs),
-                  DropdownButtonFormField<int>(
-                    initialValue: cubit.subjectCategoryID,
-                    decoration: const InputDecoration(
-                      border: OutlineInputBorder(),
-                      isDense: true,
-                      contentPadding: EdgeInsets.symmetric(
-                        horizontal: AppSizes.spaceSm,
-                        vertical: AppSizes.spaceSm,
-                      ),
+                  ],
+                ),
+                const Gap(AppSizes.spaceXs),
+                DropdownButtonFormField<int>(
+                  initialValue: cubit.subjectCategoryID,
+                  decoration: const InputDecoration(
+                    border: OutlineInputBorder(),
+                    isDense: true,
+                    contentPadding: EdgeInsets.symmetric(
+                      horizontal: AppSizes.spaceSm,
+                      vertical: AppSizes.spaceSm,
                     ),
-                    hint: Text(
+                  ),
+                  hint: Text(
+                    _subjectCategories.isEmpty
+                        ? 'Enter domain to load categories'
+                        : 'Select a subject category',
+                  ),
+                  items:
+                      _subjectCategories.map((category) {
+                        return DropdownMenuItem(
+                          value: category.id,
+                          child: Text(category.name),
+                        );
+                      }).toList(),
+                  onChanged:
                       _subjectCategories.isEmpty
-                          ? 'Enter domain to load categories'
-                          : 'Select a subject category',
-                    ),
-                    items:
-                        _subjectCategories.map((category) {
-                          return DropdownMenuItem(
-                            value: category.id,
-                            child: Text(category.name),
-                          );
-                        }).toList(),
-                    onChanged:
-                        _subjectCategories.isEmpty
-                            ? null
-                            : (value) {
-                              context
-                                  .read<SubjectsCubit>()
-                                  .setSubjectCategoryID(value);
-                            },
-                  ),
-                  const Gap(AppSizes.spaceXs),
-                  Text(
-                    'Filter subjects by category',
-                    style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                      color: Theme.of(context).colorScheme.onSurfaceVariant,
-                    ),
-                  ),
-                ],
-              ),
-
-              if (cubit.subjectCategoryID != null) ...[
-                const Gap(AppSizes.spaceMd),
-                SizedBox(
-                  width: double.infinity,
-                  child: OutlinedButton.icon(
-                    onPressed: () {
-                      context.read<SubjectsCubit>().clearFilters();
-                    },
-                    icon: const Icon(Icons.clear, size: 16),
-                    label: const Text('Clear Filter'),
+                          ? null
+                          : (value) {
+                            context.read<SubjectsCubit>().setSubjectCategoryID(
+                              value,
+                            );
+                          },
+                ),
+                const Gap(AppSizes.spaceXs),
+                Text(
+                  'Filter subjects by category',
+                  style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                    color: Theme.of(context).colorScheme.onSurfaceVariant,
                   ),
                 ),
               ],
+            ),
+            if (cubit.subjectCategoryID != null) ...[
+              const Gap(AppSizes.spaceMd),
+              SizedBox(
+                width: double.infinity,
+                child: OutlinedButton.icon(
+                  onPressed: () {
+                    context.read<SubjectsCubit>().clearFilters();
+                  },
+                  icon: const Icon(Icons.clear, size: 16),
+                  label: const Text('Clear Filter'),
+                ),
+              ),
             ],
-          ),
+          ],
         );
       },
     );

--- a/app/example/lib/features/units/presentation/widgets/units_parameters_panel.dart
+++ b/app/example/lib/features/units/presentation/widgets/units_parameters_panel.dart
@@ -6,6 +6,7 @@ import 'package:searchable_paginated_dropdown/searchable_paginated_dropdown.dart
 import 'package:stadata_example/core/constants/app_sizes.dart';
 import 'package:stadata_example/core/generated/strings.g.dart';
 import 'package:stadata_example/features/units/presentation/cubit/units_cubit.dart';
+import 'package:stadata_example/shared/widgets/parameters_panel.dart';
 import 'package:stadata_flutter_sdk/stadata_flutter_sdk.dart';
 
 class UnitsParametersPanel extends StatefulWidget {
@@ -36,181 +37,127 @@ class _UnitsParametersPanelState extends State<UnitsParametersPanel> {
     final t = Translations.of(context);
     final cubit = context.read<UnitsCubit>();
 
-    return Container(
-      width: double.infinity,
-      padding: const EdgeInsets.all(AppSizes.spaceMd),
-      decoration: BoxDecoration(
-        color: Colors.white,
-        borderRadius: BorderRadius.circular(8),
-        border: Border.all(
-          color: Theme.of(context).colorScheme.outline.withValues(alpha: 0.3),
+    return ParametersPanel(
+      icon: Icons.tune,
+      title: 'Parameters',
+      children: [
+        // Domain field
+        ParameterField(
+          label: 'Domain *',
+          child: TextFormField(
+            controller: _domainController,
+            decoration: const InputDecoration(
+              border: OutlineInputBorder(),
+              hintText: 'e.g., 7200 (4 digits)',
+              isDense: true,
+              contentPadding: EdgeInsets.symmetric(
+                horizontal: AppSizes.spaceSm,
+                vertical: AppSizes.spaceSm,
+              ),
+            ),
+            keyboardType: TextInputType.number,
+            inputFormatters: [FilteringTextInputFormatter.digitsOnly],
+            maxLength: 4,
+            onChanged: cubit.setDomain,
+          ),
         ),
-      ),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Row(
-            children: [
-              Icon(
-                Icons.tune,
-                size: 16,
-                color: Theme.of(context).colorScheme.primary,
+        const Gap(AppSizes.spaceMd),
+        // Language dropdown
+        ParameterField(
+          label: 'Language',
+          child: DropdownButtonFormField<DataLanguage>(
+            initialValue: cubit.currentLanguage,
+            decoration: const InputDecoration(
+              border: OutlineInputBorder(),
+              isDense: true,
+              contentPadding: EdgeInsets.symmetric(
+                horizontal: AppSizes.spaceSm,
+                vertical: AppSizes.spaceSm,
               ),
-              const Gap(AppSizes.spaceXs),
-              Text(
-                'Parameters',
-                style: Theme.of(
-                  context,
-                ).textTheme.titleSmall?.copyWith(fontWeight: FontWeight.w600),
-              ),
-            ],
-          ),
-          const Gap(AppSizes.spaceMd),
-          // Domain field
-          Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              Text(
-                'Domain *',
-                style: Theme.of(
-                  context,
-                ).textTheme.labelMedium?.copyWith(fontWeight: FontWeight.w500),
-              ),
-              const Gap(AppSizes.spaceXs),
-              TextFormField(
-                controller: _domainController,
-                decoration: const InputDecoration(
-                  border: OutlineInputBorder(),
-                  hintText: 'e.g., 7200 (4 digits)',
-                  isDense: true,
-                  contentPadding: EdgeInsets.symmetric(
-                    horizontal: AppSizes.spaceSm,
-                    vertical: AppSizes.spaceSm,
-                  ),
-                ),
-                keyboardType: TextInputType.number,
-                inputFormatters: [FilteringTextInputFormatter.digitsOnly],
-                maxLength: 4,
-                onChanged: cubit.setDomain,
-              ),
-            ],
-          ),
-          const Gap(AppSizes.spaceMd),
-          // Language dropdown
-          Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              Text(
-                'Language',
-                style: Theme.of(
-                  context,
-                ).textTheme.labelMedium?.copyWith(fontWeight: FontWeight.w500),
-              ),
-              const Gap(AppSizes.spaceXs),
-              DropdownButtonFormField<DataLanguage>(
-                initialValue: cubit.currentLanguage,
-                decoration: const InputDecoration(
-                  border: OutlineInputBorder(),
-                  isDense: true,
-                  contentPadding: EdgeInsets.symmetric(
-                    horizontal: AppSizes.spaceSm,
-                    vertical: AppSizes.spaceSm,
-                  ),
-                ),
-                items:
-                    DataLanguage.values.map((lang) {
-                      return DropdownMenuItem(
-                        value: lang,
-                        child: Text(
-                          lang == DataLanguage.id
-                              ? t.instructions.languageLabels.indonesian
-                              : t.instructions.languageLabels.english,
-                        ),
-                      );
-                    }).toList(),
-                onChanged: (value) {
-                  if (value != null) {
-                    cubit.changeLanguage(value);
-                  }
-                },
-              ),
-            ],
-          ),
-          const Gap(AppSizes.spaceMd),
-          // Variable dropdown (optional, paginated)
-          Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              Text(
-                'Variable ID (Optional)',
-                style: Theme.of(
-                  context,
-                ).textTheme.labelMedium?.copyWith(fontWeight: FontWeight.w500),
-              ),
-              const Gap(AppSizes.spaceXs),
-              SearchableDropdown<Variable>.paginated(
-                requestItemCount: 10,
-                hintText: Text(
-                  cubit.canLoadData
-                      ? 'Select a variable (optional)'
-                      : 'Enter domain first (4 digits)',
-                ),
-                isEnabled: cubit.canLoadData,
-                paginatedRequest: (page, searchKey) async {
-                  if (!cubit.canLoadData) {
-                    return [];
-                  }
-                  final variables = await cubit.fetchVariables(
-                    page: page,
-                    searchText: searchKey,
+            ),
+            items:
+                DataLanguage.values.map((lang) {
+                  return DropdownMenuItem(
+                    value: lang,
+                    child: Text(
+                      lang == DataLanguage.id
+                          ? t.instructions.languageLabels.indonesian
+                          : t.instructions.languageLabels.english,
+                    ),
                   );
-                  return variables
-                      .map(
-                        (variable) => SearchableDropdownMenuItem<Variable>(
-                          value: variable,
-                          label: variable.title,
-                          child: ListTile(
-                            contentPadding: EdgeInsets.zero,
-                            title: Text(
-                              variable.title,
-                              style: Theme.of(context).textTheme.bodyMedium,
-                            ),
-                            subtitle: Text(
-                              variable.subjectName,
-                              style: Theme.of(
-                                context,
-                              ).textTheme.bodySmall?.copyWith(
-                                color:
-                                    Theme.of(
-                                      context,
-                                    ).colorScheme.onSurfaceVariant,
-                              ),
-                            ),
+                }).toList(),
+            onChanged: (value) {
+              if (value != null) {
+                cubit.changeLanguage(value);
+              }
+            },
+          ),
+        ),
+        const Gap(AppSizes.spaceMd),
+        // Variable dropdown (optional, paginated)
+        ParameterField(
+          label: 'Variable ID (Optional)',
+          child: SearchableDropdown<Variable>.paginated(
+            requestItemCount: 10,
+            hintText: Text(
+              cubit.canLoadData
+                  ? 'Select a variable (optional)'
+                  : 'Enter domain first (4 digits)',
+            ),
+            isEnabled: cubit.canLoadData,
+            paginatedRequest: (page, searchKey) async {
+              if (!cubit.canLoadData) {
+                return [];
+              }
+              final variables = await cubit.fetchVariables(
+                page: page,
+                searchText: searchKey,
+              );
+              return variables
+                  .map(
+                    (variable) => SearchableDropdownMenuItem<Variable>(
+                      value: variable,
+                      label: variable.title,
+                      child: ListTile(
+                        contentPadding: EdgeInsets.zero,
+                        title: Text(
+                          variable.title,
+                          style: Theme.of(context).textTheme.bodyMedium,
+                        ),
+                        subtitle: Text(
+                          variable.subjectName,
+                          style: Theme.of(
+                            context,
+                          ).textTheme.bodySmall?.copyWith(
+                            color:
+                                Theme.of(
+                                  context,
+                                ).colorScheme.onSurfaceVariant,
                           ),
                         ),
-                      )
-                      .toList();
-                },
-                onChanged: (variable) {
-                  cubit.setVariableID(variable?.id);
-                },
-                backgroundDecoration:
-                    (child) => Card(
-                      margin: EdgeInsets.zero,
-                      elevation: 0,
-                      shape: RoundedRectangleBorder(
-                        borderRadius: BorderRadius.circular(8),
-                        side: BorderSide(
-                          color: Theme.of(context).colorScheme.outline,
-                        ),
                       ),
-                      child: child,
                     ),
-              ),
-            ],
+                  )
+                  .toList();
+            },
+            onChanged: (variable) {
+              cubit.setVariableID(variable?.id);
+            },
+            backgroundDecoration:
+                (child) => Card(
+                  margin: EdgeInsets.zero,
+                  elevation: 0,
+                  shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(8),
+                    side: BorderSide(
+                      color: Theme.of(context).colorScheme.outline,
+                    ),
+                  ),
+                  child: child,
+                ),
           ),
-        ],
-      ),
+        ),
+      ],
     );
   }
 }

--- a/app/example/lib/features/variables/presentation/widgets/variables_parameters_panel.dart
+++ b/app/example/lib/features/variables/presentation/widgets/variables_parameters_panel.dart
@@ -7,6 +7,7 @@ import 'package:stadata_example/core/constants/app_sizes.dart';
 import 'package:stadata_example/core/generated/strings.g.dart';
 import 'package:stadata_example/features/variables/presentation/cubit/variables_cubit.dart';
 import 'package:stadata_example/shared/cubit/base_cubit.dart';
+import 'package:stadata_example/shared/widgets/parameters_panel.dart';
 import 'package:stadata_flutter_sdk/stadata_flutter_sdk.dart';
 
 class VariablesParametersPanel extends StatefulWidget {
@@ -38,243 +39,180 @@ class _VariablesParametersPanelState extends State<VariablesParametersPanel> {
     final t = Translations.of(context);
     final cubit = context.read<VariablesCubit>();
 
-    return Container(
-      width: double.infinity,
-      padding: const EdgeInsets.all(AppSizes.spaceMd),
-      decoration: BoxDecoration(
-        color: Colors.white,
-        borderRadius: BorderRadius.circular(8),
-        border: Border.all(
-          color: Theme.of(context).colorScheme.outline.withValues(alpha: 0.3),
+    return ParametersPanel(
+      icon: Icons.tune,
+      title: t.variables.parameters.title,
+      children: [
+        // Domain field
+        ParameterField(
+          label: t.variables.parameters.domain,
+          child: TextFormField(
+            controller: _domainController,
+            decoration: InputDecoration(
+              border: const OutlineInputBorder(),
+              hintText: t.variables.parameters.domainHint,
+              isDense: true,
+              contentPadding: const EdgeInsets.symmetric(
+                horizontal: AppSizes.spaceSm,
+                vertical: AppSizes.spaceSm,
+              ),
+            ),
+            keyboardType: TextInputType.number,
+            inputFormatters: [FilteringTextInputFormatter.digitsOnly],
+            maxLength: 4,
+            onChanged: cubit.setDomain,
+          ),
         ),
-      ),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Row(
-            children: [
-              Icon(
-                Icons.tune,
-                size: 16,
-                color: Theme.of(context).colorScheme.primary,
+        const Gap(AppSizes.spaceMd),
+        // Language dropdown
+        ParameterField(
+          label: t.variables.parameters.language,
+          child: DropdownButtonFormField<DataLanguage>(
+            initialValue: cubit.currentLanguage,
+            decoration: const InputDecoration(
+              border: OutlineInputBorder(),
+              isDense: true,
+              contentPadding: EdgeInsets.symmetric(
+                horizontal: AppSizes.spaceSm,
+                vertical: AppSizes.spaceSm,
               ),
-              const Gap(AppSizes.spaceXs),
-              Text(
-                t.variables.parameters.title,
-                style: Theme.of(
-                  context,
-                ).textTheme.titleSmall?.copyWith(fontWeight: FontWeight.w600),
-              ),
-            ],
-          ),
-          const Gap(AppSizes.spaceMd),
-          // Domain field
-          Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              Text(
-                t.variables.parameters.domain,
-                style: Theme.of(
-                  context,
-                ).textTheme.labelMedium?.copyWith(fontWeight: FontWeight.w500),
-              ),
-              const Gap(AppSizes.spaceXs),
-              TextFormField(
-                controller: _domainController,
-                decoration: InputDecoration(
-                  border: const OutlineInputBorder(),
-                  hintText: t.variables.parameters.domainHint,
-                  isDense: true,
-                  contentPadding: const EdgeInsets.symmetric(
-                    horizontal: AppSizes.spaceSm,
-                    vertical: AppSizes.spaceSm,
-                  ),
-                ),
-                keyboardType: TextInputType.number,
-                inputFormatters: [FilteringTextInputFormatter.digitsOnly],
-                maxLength: 4,
-                onChanged: cubit.setDomain,
-              ),
-            ],
-          ),
-          const Gap(AppSizes.spaceMd),
-          // Language dropdown
-          Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              Text(
-                t.variables.parameters.language,
-                style: Theme.of(
-                  context,
-                ).textTheme.labelMedium?.copyWith(fontWeight: FontWeight.w500),
-              ),
-              const Gap(AppSizes.spaceXs),
-              DropdownButtonFormField<DataLanguage>(
-                initialValue: cubit.currentLanguage,
-                decoration: const InputDecoration(
-                  border: OutlineInputBorder(),
-                  isDense: true,
-                  contentPadding: EdgeInsets.symmetric(
-                    horizontal: AppSizes.spaceSm,
-                    vertical: AppSizes.spaceSm,
-                  ),
-                ),
-                items:
-                    DataLanguage.values.map((lang) {
-                      return DropdownMenuItem(
-                        value: lang,
-                        child: Text(
-                          lang == DataLanguage.id
-                              ? t.instructions.languageLabels.indonesian
-                              : t.instructions.languageLabels.english,
-                        ),
-                      );
-                    }).toList(),
-                onChanged: (value) {
-                  if (value != null) {
-                    cubit.changeLanguage(value);
-                  }
-                },
-              ),
-            ],
-          ),
-          const Gap(AppSizes.spaceMd),
-          // Year field (optional)
-          Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              Text(
-                t.variables.parameters.year,
-                style: Theme.of(
-                  context,
-                ).textTheme.labelMedium?.copyWith(fontWeight: FontWeight.w500),
-              ),
-              const Gap(AppSizes.spaceXs),
-              TextFormField(
-                decoration: InputDecoration(
-                  border: const OutlineInputBorder(),
-                  hintText: t.variables.parameters.yearHint,
-                  isDense: true,
-                  contentPadding: const EdgeInsets.symmetric(
-                    horizontal: AppSizes.spaceSm,
-                    vertical: AppSizes.spaceSm,
-                  ),
-                ),
-                keyboardType: TextInputType.number,
-                inputFormatters: [FilteringTextInputFormatter.digitsOnly],
-                onChanged: (value) {
-                  if (value.isEmpty) {
-                    cubit.setYear(null);
-                  } else {
-                    cubit.setYear(int.tryParse(value));
-                  }
-                },
-              ),
-            ],
-          ),
-          const Gap(AppSizes.spaceMd),
-          // Subject dropdown (optional, paginated)
-          Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              Text(
-                t.variables.parameters.subject,
-                style: Theme.of(
-                  context,
-                ).textTheme.labelMedium?.copyWith(fontWeight: FontWeight.w500),
-              ),
-              const Gap(AppSizes.spaceXs),
-              SearchableDropdown<Subject>.paginated(
-                requestItemCount: 10,
-                hintText: Text(
-                  cubit.canLoadData
-                      ? t.variables.parameters.subjectHint
-                      : 'Enter domain first (4 digits)',
-                ),
-                isEnabled: cubit.canLoadData,
-                paginatedRequest: (page, searchKey) async {
-                  if (!cubit.canLoadData) {
-                    return [];
-                  }
-                  final subjects = await cubit.fetchSubjects(
-                    page: page,
-                    searchText: searchKey,
-                  );
-                  return subjects
-                      .map(
-                        (subject) => SearchableDropdownMenuItem<Subject>(
-                          value: subject,
-                          label: subject.name,
-                          child: ListTile(
-                            contentPadding: EdgeInsets.zero,
-                            title: Text(
-                              subject.name,
-                              style: Theme.of(context).textTheme.bodyMedium,
-                            ),
-                            subtitle:
-                                subject.category != null
-                                    ? Text(
-                                      subject.category!.name,
-                                      style: Theme.of(
-                                        context,
-                                      ).textTheme.bodySmall?.copyWith(
-                                        color:
-                                            Theme.of(
-                                              context,
-                                            ).colorScheme.onSurfaceVariant,
-                                      ),
-                                    )
-                                    : null,
-                          ),
-                        ),
-                      )
-                      .toList();
-                },
-                onChanged: (subject) {
-                  cubit.setSubjectID(subject?.id);
-                },
-                backgroundDecoration:
-                    (child) => Card(
-                      margin: EdgeInsets.zero,
-                      elevation: 0,
-                      shape: RoundedRectangleBorder(
-                        borderRadius: BorderRadius.circular(8),
-                        side: BorderSide(
-                          color: Theme.of(context).colorScheme.outline,
-                        ),
-                      ),
-                      child: child,
-                    ),
-              ),
-            ],
-          ),
-          const Gap(AppSizes.spaceMd),
-          // Show Existing Variables switch
-          BlocBuilder<VariablesCubit, BaseState>(
-            builder: (context, state) {
-              final switchCubit = context.read<VariablesCubit>();
-              return Row(
-                children: [
-                  Expanded(
+            ),
+            items:
+                DataLanguage.values.map((lang) {
+                  return DropdownMenuItem(
+                    value: lang,
                     child: Text(
-                      t.variables.parameters.showExistingVariables,
-                      style: Theme.of(context).textTheme.labelMedium?.copyWith(
-                        fontWeight: FontWeight.w500,
-                      ),
+                      lang == DataLanguage.id
+                          ? t.instructions.languageLabels.indonesian
+                          : t.instructions.languageLabels.english,
                     ),
-                  ),
-                  Switch(
-                    value: switchCubit.showExistingVariables,
-                    onChanged: (value) {
-                      switchCubit.setShowExistingVariables(value: value);
-                    },
-                  ),
-                ],
-              );
+                  );
+                }).toList(),
+            onChanged: (value) {
+              if (value != null) {
+                cubit.changeLanguage(value);
+              }
             },
           ),
-        ],
-      ),
+        ),
+        const Gap(AppSizes.spaceMd),
+        // Year field (optional)
+        ParameterField(
+          label: t.variables.parameters.year,
+          child: TextFormField(
+            decoration: InputDecoration(
+              border: const OutlineInputBorder(),
+              hintText: t.variables.parameters.yearHint,
+              isDense: true,
+              contentPadding: const EdgeInsets.symmetric(
+                horizontal: AppSizes.spaceSm,
+                vertical: AppSizes.spaceSm,
+              ),
+            ),
+            keyboardType: TextInputType.number,
+            inputFormatters: [FilteringTextInputFormatter.digitsOnly],
+            onChanged: (value) {
+              if (value.isEmpty) {
+                cubit.setYear(null);
+              } else {
+                cubit.setYear(int.tryParse(value));
+              }
+            },
+          ),
+        ),
+        const Gap(AppSizes.spaceMd),
+        // Subject dropdown (optional, paginated)
+        ParameterField(
+          label: t.variables.parameters.subject,
+          child: SearchableDropdown<Subject>.paginated(
+            requestItemCount: 10,
+            hintText: Text(
+              cubit.canLoadData
+                  ? t.variables.parameters.subjectHint
+                  : 'Enter domain first (4 digits)',
+            ),
+            isEnabled: cubit.canLoadData,
+            paginatedRequest: (page, searchKey) async {
+              if (!cubit.canLoadData) {
+                return [];
+              }
+              final subjects = await cubit.fetchSubjects(
+                page: page,
+                searchText: searchKey,
+              );
+              return subjects
+                  .map(
+                    (subject) => SearchableDropdownMenuItem<Subject>(
+                      value: subject,
+                      label: subject.name,
+                      child: ListTile(
+                        contentPadding: EdgeInsets.zero,
+                        title: Text(
+                          subject.name,
+                          style: Theme.of(context).textTheme.bodyMedium,
+                        ),
+                        subtitle:
+                            subject.category != null
+                                ? Text(
+                                  subject.category!.name,
+                                  style: Theme.of(
+                                    context,
+                                  ).textTheme.bodySmall?.copyWith(
+                                    color:
+                                        Theme.of(
+                                          context,
+                                        ).colorScheme.onSurfaceVariant,
+                                  ),
+                                )
+                                : null,
+                      ),
+                    ),
+                  )
+                  .toList();
+            },
+            onChanged: (subject) {
+              cubit.setSubjectID(subject?.id);
+            },
+            backgroundDecoration:
+                (child) => Card(
+                  margin: EdgeInsets.zero,
+                  elevation: 0,
+                  shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(8),
+                    side: BorderSide(
+                      color: Theme.of(context).colorScheme.outline,
+                    ),
+                  ),
+                  child: child,
+                ),
+          ),
+        ),
+        const Gap(AppSizes.spaceMd),
+        // Show Existing Variables switch
+        BlocBuilder<VariablesCubit, BaseState>(
+          builder: (context, state) {
+            final switchCubit = context.read<VariablesCubit>();
+            return Row(
+              children: [
+                Expanded(
+                  child: Text(
+                    t.variables.parameters.showExistingVariables,
+                    style: Theme.of(context).textTheme.labelMedium?.copyWith(
+                      fontWeight: FontWeight.w500,
+                    ),
+                  ),
+                ),
+                Switch(
+                  value: switchCubit.showExistingVariables,
+                  onChanged: (value) {
+                    switchCubit.setShowExistingVariables(value: value);
+                  },
+                ),
+              ],
+            );
+          },
+        ),
+      ],
     );
   }
 }

--- a/app/example/lib/features/vertical_variables/presentation/widgets/vertical_variables_parameters_panel.dart
+++ b/app/example/lib/features/vertical_variables/presentation/widgets/vertical_variables_parameters_panel.dart
@@ -6,6 +6,7 @@ import 'package:searchable_paginated_dropdown/searchable_paginated_dropdown.dart
 import 'package:stadata_example/core/constants/app_sizes.dart';
 import 'package:stadata_example/core/generated/strings.g.dart';
 import 'package:stadata_example/features/vertical_variables/presentation/cubit/vertical_variables_cubit.dart';
+import 'package:stadata_example/shared/widgets/parameters_panel.dart';
 import 'package:stadata_flutter_sdk/stadata_flutter_sdk.dart';
 
 class VerticalVariablesParametersPanel extends StatefulWidget {
@@ -38,181 +39,127 @@ class _VerticalVariablesParametersPanelState
     final t = Translations.of(context);
     final cubit = context.read<VerticalVariablesCubit>();
 
-    return Container(
-      width: double.infinity,
-      padding: const EdgeInsets.all(AppSizes.spaceMd),
-      decoration: BoxDecoration(
-        color: Colors.white,
-        borderRadius: BorderRadius.circular(8),
-        border: Border.all(
-          color: Theme.of(context).colorScheme.outline.withValues(alpha: 0.3),
+    return ParametersPanel(
+      icon: Icons.tune,
+      title: 'Parameters',
+      children: [
+        // Domain field
+        ParameterField(
+          label: 'Domain *',
+          child: TextFormField(
+            controller: _domainController,
+            decoration: const InputDecoration(
+              border: OutlineInputBorder(),
+              hintText: 'e.g., 7200 (4 digits)',
+              isDense: true,
+              contentPadding: EdgeInsets.symmetric(
+                horizontal: AppSizes.spaceSm,
+                vertical: AppSizes.spaceSm,
+              ),
+            ),
+            keyboardType: TextInputType.number,
+            inputFormatters: [FilteringTextInputFormatter.digitsOnly],
+            maxLength: 4,
+            onChanged: cubit.setDomain,
+          ),
         ),
-      ),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Row(
-            children: [
-              Icon(
-                Icons.tune,
-                size: 16,
-                color: Theme.of(context).colorScheme.primary,
+        const Gap(AppSizes.spaceMd),
+        // Language dropdown
+        ParameterField(
+          label: 'Language',
+          child: DropdownButtonFormField<DataLanguage>(
+            initialValue: cubit.currentLanguage,
+            decoration: const InputDecoration(
+              border: OutlineInputBorder(),
+              isDense: true,
+              contentPadding: EdgeInsets.symmetric(
+                horizontal: AppSizes.spaceSm,
+                vertical: AppSizes.spaceSm,
               ),
-              const Gap(AppSizes.spaceXs),
-              Text(
-                'Parameters',
-                style: Theme.of(
-                  context,
-                ).textTheme.titleSmall?.copyWith(fontWeight: FontWeight.w600),
-              ),
-            ],
-          ),
-          const Gap(AppSizes.spaceMd),
-          // Domain field
-          Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              Text(
-                'Domain *',
-                style: Theme.of(
-                  context,
-                ).textTheme.labelMedium?.copyWith(fontWeight: FontWeight.w500),
-              ),
-              const Gap(AppSizes.spaceXs),
-              TextFormField(
-                controller: _domainController,
-                decoration: const InputDecoration(
-                  border: OutlineInputBorder(),
-                  hintText: 'e.g., 7200 (4 digits)',
-                  isDense: true,
-                  contentPadding: EdgeInsets.symmetric(
-                    horizontal: AppSizes.spaceSm,
-                    vertical: AppSizes.spaceSm,
-                  ),
-                ),
-                keyboardType: TextInputType.number,
-                inputFormatters: [FilteringTextInputFormatter.digitsOnly],
-                maxLength: 4,
-                onChanged: cubit.setDomain,
-              ),
-            ],
-          ),
-          const Gap(AppSizes.spaceMd),
-          // Language dropdown
-          Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              Text(
-                'Language',
-                style: Theme.of(
-                  context,
-                ).textTheme.labelMedium?.copyWith(fontWeight: FontWeight.w500),
-              ),
-              const Gap(AppSizes.spaceXs),
-              DropdownButtonFormField<DataLanguage>(
-                initialValue: cubit.currentLanguage,
-                decoration: const InputDecoration(
-                  border: OutlineInputBorder(),
-                  isDense: true,
-                  contentPadding: EdgeInsets.symmetric(
-                    horizontal: AppSizes.spaceSm,
-                    vertical: AppSizes.spaceSm,
-                  ),
-                ),
-                items:
-                    DataLanguage.values.map((lang) {
-                      return DropdownMenuItem(
-                        value: lang,
-                        child: Text(
-                          lang == DataLanguage.id
-                              ? t.instructions.languageLabels.indonesian
-                              : t.instructions.languageLabels.english,
-                        ),
-                      );
-                    }).toList(),
-                onChanged: (value) {
-                  if (value != null) {
-                    cubit.changeLanguage(value);
-                  }
-                },
-              ),
-            ],
-          ),
-          const Gap(AppSizes.spaceMd),
-          // Variable dropdown (optional, paginated)
-          Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              Text(
-                t.verticalVariables.parameters.variableID,
-                style: Theme.of(
-                  context,
-                ).textTheme.labelMedium?.copyWith(fontWeight: FontWeight.w500),
-              ),
-              const Gap(AppSizes.spaceXs),
-              SearchableDropdown<Variable>.paginated(
-                requestItemCount: 10,
-                hintText: Text(
-                  cubit.canLoadData
-                      ? t.verticalVariables.parameters.variableIDHint
-                      : 'Enter domain first (4 digits)',
-                ),
-                isEnabled: cubit.canLoadData,
-                paginatedRequest: (page, searchKey) async {
-                  if (!cubit.canLoadData) {
-                    return [];
-                  }
-                  final variables = await cubit.fetchVariables(
-                    page: page,
-                    searchText: searchKey,
+            ),
+            items:
+                DataLanguage.values.map((lang) {
+                  return DropdownMenuItem(
+                    value: lang,
+                    child: Text(
+                      lang == DataLanguage.id
+                          ? t.instructions.languageLabels.indonesian
+                          : t.instructions.languageLabels.english,
+                    ),
                   );
-                  return variables
-                      .map(
-                        (variable) => SearchableDropdownMenuItem<Variable>(
-                          value: variable,
-                          label: variable.title,
-                          child: ListTile(
-                            contentPadding: EdgeInsets.zero,
-                            title: Text(
-                              variable.title,
-                              style: Theme.of(context).textTheme.bodyMedium,
-                            ),
-                            subtitle: Text(
-                              variable.subjectName,
-                              style: Theme.of(
-                                context,
-                              ).textTheme.bodySmall?.copyWith(
-                                color:
-                                    Theme.of(
-                                      context,
-                                    ).colorScheme.onSurfaceVariant,
-                              ),
-                            ),
+                }).toList(),
+            onChanged: (value) {
+              if (value != null) {
+                cubit.changeLanguage(value);
+              }
+            },
+          ),
+        ),
+        const Gap(AppSizes.spaceMd),
+        // Variable dropdown (optional, paginated)
+        ParameterField(
+          label: t.verticalVariables.parameters.variableID,
+          child: SearchableDropdown<Variable>.paginated(
+            requestItemCount: 10,
+            hintText: Text(
+              cubit.canLoadData
+                  ? t.verticalVariables.parameters.variableIDHint
+                  : 'Enter domain first (4 digits)',
+            ),
+            isEnabled: cubit.canLoadData,
+            paginatedRequest: (page, searchKey) async {
+              if (!cubit.canLoadData) {
+                return [];
+              }
+              final variables = await cubit.fetchVariables(
+                page: page,
+                searchText: searchKey,
+              );
+              return variables
+                  .map(
+                    (variable) => SearchableDropdownMenuItem<Variable>(
+                      value: variable,
+                      label: variable.title,
+                      child: ListTile(
+                        contentPadding: EdgeInsets.zero,
+                        title: Text(
+                          variable.title,
+                          style: Theme.of(context).textTheme.bodyMedium,
+                        ),
+                        subtitle: Text(
+                          variable.subjectName,
+                          style: Theme.of(
+                            context,
+                          ).textTheme.bodySmall?.copyWith(
+                            color:
+                                Theme.of(
+                                  context,
+                                ).colorScheme.onSurfaceVariant,
                           ),
                         ),
-                      )
-                      .toList();
-                },
-                onChanged: (variable) {
-                  cubit.setVariableID(variable?.id);
-                },
-                backgroundDecoration:
-                    (child) => Card(
-                      margin: EdgeInsets.zero,
-                      elevation: 0,
-                      shape: RoundedRectangleBorder(
-                        borderRadius: BorderRadius.circular(8),
-                        side: BorderSide(
-                          color: Theme.of(context).colorScheme.outline,
-                        ),
                       ),
-                      child: child,
                     ),
-              ),
-            ],
+                  )
+                  .toList();
+            },
+            onChanged: (variable) {
+              cubit.setVariableID(variable?.id);
+            },
+            backgroundDecoration:
+                (child) => Card(
+                  margin: EdgeInsets.zero,
+                  elevation: 0,
+                  shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(8),
+                    side: BorderSide(
+                      color: Theme.of(context).colorScheme.outline,
+                    ),
+                  ),
+                  child: child,
+                ),
           ),
-        ],
-      ),
+        ),
+      ],
     );
   }
 }

--- a/app/example/lib/shared/widgets/parameters_panel.dart
+++ b/app/example/lib/shared/widgets/parameters_panel.dart
@@ -1,0 +1,115 @@
+import 'package:flutter/material.dart';
+import 'package:gap/gap.dart';
+import 'package:stadata_example/core/constants/app_sizes.dart';
+
+/// A theme-aware container card for a set of API/query parameter fields.
+///
+/// Renders a bordered, rounded card with an icon + title header followed by
+/// [children]. Unlike an ad-hoc `Container` with a hardcoded background,
+/// this widget derives its background from
+/// `Theme.of(context).colorScheme.surface`, so it stays legible whether the
+/// app is running in light or dark theme.
+///
+/// Typically paired with [ParameterField] for each individual field:
+///
+/// ```dart
+/// ParametersPanel(
+///   title: t.myFeature.parameters.title,
+///   children: [
+///     ParameterField(
+///       label: t.myFeature.parameters.domain,
+///       child: TextFormField(controller: domainController),
+///     ),
+///   ],
+/// )
+/// ```
+class ParametersPanel extends StatelessWidget {
+  const ParametersPanel({
+    required this.title,
+    required this.children,
+    super.key,
+    this.icon = Icons.settings,
+  });
+
+  /// The panel header title, shown next to [icon].
+  final String title;
+
+  /// The icon shown before [title] in the header row.
+  final IconData icon;
+
+  /// The panel body, typically a list of [ParameterField]s and spacing.
+  final List<Widget> children;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.all(AppSizes.spaceMd),
+      decoration: BoxDecoration(
+        color: theme.colorScheme.surface,
+        borderRadius: BorderRadius.circular(AppSizes.radiusSm),
+        border: Border.all(
+          color: theme.colorScheme.outline.withValues(alpha: 0.3),
+        ),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              Icon(icon, size: 16, color: theme.colorScheme.primary),
+              const Gap(AppSizes.spaceXs),
+              Text(
+                title,
+                style: theme.textTheme.titleSmall?.copyWith(
+                  fontWeight: FontWeight.w600,
+                  color: theme.colorScheme.onSurface,
+                ),
+              ),
+            ],
+          ),
+          const Gap(AppSizes.spaceMd),
+          ...children,
+        ],
+      ),
+    );
+  }
+}
+
+/// A labeled wrapper for a single parameter field inside a [ParametersPanel].
+///
+/// Renders [label] above [child] (typically a [TextFormField] or
+/// [DropdownButtonFormField]) using an explicit
+/// `colorScheme.onSurface`-derived color, rather than relying on whatever
+/// color the ambient `labelMedium` text style happens to resolve to.
+class ParameterField extends StatelessWidget {
+  const ParameterField({required this.label, required this.child, super.key});
+
+  /// The field label, shown above [child].
+  final String label;
+
+  /// The form field (or group of widgets) this label describes.
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          label,
+          style: theme.textTheme.labelMedium?.copyWith(
+            fontWeight: FontWeight.w500,
+            color: theme.colorScheme.onSurface,
+          ),
+        ),
+        const Gap(AppSizes.spaceXs),
+        child,
+      ],
+    );
+  }
+}


### PR DESCRIPTION
## Summary

A user-reported screenshot showed the "API Parameters" card on the Glossary screen with nearly-invisible text in dark theme — light-gray labels/hints on a hardcoded white card. Root cause, present identically in ~27 `*_parameters_panel.dart` files: each one's `Container` hardcoded `color: Colors.white`, while label text used `theme.textTheme.labelMedium`, which resolves to a light color in dark theme — legible on a real dark card, illegible on the hardcoded white one. Each file also duplicated its own private `_ParameterField` widget.

## Changes

- Added `ParametersPanel`/`ParameterField` to `app/example/lib/shared/widgets/parameters_panel.dart`, using `colorScheme.surface`/`onSurface` instead of hardcoded colors so the card is legible in both light and dark theme.
- Migrated all 23 feature panel files to the shared widget, removing the duplicated `Container`/`BoxDecoration`/`_ParameterField` boilerplate. Feature-specific form fields (TextFormField, DropdownButtonFormField, etc.) are untouched — only the wrapping container/label widgets changed.

## ⚠️ Note on verification

I was unable to complete a full live visual re-test (light + dark theme screenshots on-device) — the local Android emulator became unresponsive (host resource exhaustion after an extended session, manifesting as recurring "System UI isn't responding" ANRs) across two separate boot attempts, and iOS Simulator has no scriptable tap synthesis for unattended navigation. What I *did* verify:

- [x] `fvm exec melos analyze` — clean, only 3 pre-existing `info`-level hits in unrelated files
- [x] `grep` confirms zero remaining `color: Colors.white` or duplicated `_ParameterField` instances across any panel file
- [x] Manual review of the shared widget + a full sample migrated file (`glossary_parameters_panel.dart`) against the original — logic/fields identical, only the container/label styling changed
- [x] Confirmed `AppSizes.radiusSm` (8) matches the original hardcoded `BorderRadius.circular(8)` exactly, so no visual regression to border radius
- [ ] Live on-device dark/light theme screenshot comparison (blocked by emulator instability — **please verify visually before merging**)

Given the fix is a small, well-understood Flutter pattern (swap a hardcoded color for a `colorScheme`-derived one, which is exactly what `colorScheme.surface`/`onSurface` are designed for), I'm confident in the change, but flagging the incomplete live verification transparently rather than claiming something I didn't confirm.

Tracked in beads: stadata_flutter_sdk-r4l.

## Test plan

- [x] `melos analyze` clean
- [ ] Manually verify Glossary (and a couple other feature) parameter cards are legible in both light and dark theme before merging
- [ ] CI green